### PR TITLE
fix: change Instances from #inline to #example

### DIFF
--- a/input/fsh/Instances/FVC.fsh
+++ b/input/fsh/Instances/FVC.fsh
@@ -67,7 +67,7 @@ Usage: #example
 Instance: FVC_POST
 InstanceOf: Observation
 Title: "FVC (L) post-bronchodilator"
-Usage: #inline
+Usage: #example
 * id = "FVC-POST"
 * status = #final
 * code = $LNC#19874-7 "Forced vital capacity [Volume] Respiratory system by Spirometry --post bronchodilation"
@@ -83,7 +83,7 @@ Usage: #inline
 Instance: FVC_POST_zScore
 InstanceOf: Observation
 Title: "FVC z-score post-bronchodilator"
-Usage: #inline
+Usage: #example
 * id = "FVC-POST-Zscore"
 * status = #final
 * code
@@ -100,7 +100,7 @@ Usage: #inline
 Instance: FVC_POST_percentPredicted
 InstanceOf: Observation
 Title: "FVC post-bronchodilator, % of predicted value"
-Usage: #inline
+Usage: #example
 * id = "FVC-POST-percentPredicted"
 * status = #final
 * code = $LNC#19873-9 "FVC post bronchodilation measured/predicted"
@@ -111,7 +111,7 @@ Usage: #inline
 Instance: FVC_POST_mLChange
 InstanceOf: Observation
 Title: "FVC post-bronchodilator, change from pre-bronchodilator (mL)"
-Usage: #inline
+Usage: #example
 * id = "FVC-POST-mLChange"
 * status = #final
 * code
@@ -123,7 +123,7 @@ Usage: #inline
 Instance: FVC_POST_percentChange
 InstanceOf: Observation
 Title: "FVC post-bronchodilator, change from pre-bronchodilator (%)"
-Usage: #inline
+Usage: #example
 * id = "FVC-post-percentChange"
 * status = #final
 * code = $LNC#69982-7 "FVC percent change Respiratory system"


### PR DESCRIPTION
# Summary
We encountered the following error when attempting to use SUSHI and `publisher.jar` to create an Implementation Guide from FSH definitions:

```
Generating Narratives
Error : Cannot invoke "org.hl7.fhir.r5.renderers.utils.BaseWrappers$PropertyWrapper.hasValues()" because "t" is null
   org.hl7.fhir.r5.renderers.DiagnosticReportRenderer.fetchObservations(DiagnosticReportRenderer.java:194)
   org.hl7.fhir.r5.renderers.DiagnosticReportRenderer.render(DiagnosticReportRenderer.java:123)
   org.hl7.fhir.r5.renderers.ResourceRenderer.render(ResourceRenderer.java:84)
   org.hl7.fhir.igtools.publisher.Publisher.generateNarratives(Publisher.java:1172)
   org.hl7.fhir.igtools.publisher.Publisher.loadConformance(Publisher.java:3907)
   org.hl7.fhir.igtools.publisher.Publisher.createIg(Publisher.java:889)
   org.hl7.fhir.igtools.publisher.Publisher.execute(Publisher.java:744)
   org.hl7.fhir.igtools.ui.IGPublisherFrame$BackgroundPublisherTask.doInBackground(IGPublisherFrame.java:262)
   org.hl7.fhir.igtools.ui.IGPublisherFrame$BackgroundPublisherTask.doInBackground(IGPublisherFrame.java:251)
   java.desktop/javax.swing.SwingWorker$1.call(SwingWorker.java:304)
   java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
   java.desktop/javax.swing.SwingWorker.run(SwingWorker.java:343)
   java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
   java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630)
   java.base/java.lang.Thread.run(Thread.java:831)
```

This error was resolved by changing all FSH FVC Instances from `Usage: #inline` to `Usage: #example`.  

# Why did this work?

## Background

FSH Instances are defined with a `Usage` keyword, which can take one of three values: `#example`, `#inline`, or `#definition` (we don't care about `#definition` here; for more see https://build.fhir.org/ig/HL7/fhir-shorthand/reference.html#defining-instances).

If a FSH Instance has `Usage: #example`, then when SUSHI compiles FSH to JSON, a separate JSON resource is created from that Instance. But if the Instance is `Usage: #inline` no such resource is created - it's only instantiated inline as part of another resource.

During the IG Publisher build process, a "Report Details" table is created for the HTML page for our example DiagnosticReport. This table is populated with certain values from the referenced resources in `DiagnosticReport.result`: "Code", "Value", "Reference Range", and "When For".

## Identifying the error

As far as I can tell, the above error occurs because during the rendering of the "Report Details" table, the IG Publisher attempts to access each referenced resource of `DiagnosticReport.result` to populate that table. The IG Publisher checks in the given resource directory for a resource with the `id` of the reference. But if a referenced resource was created from an `#inline` FSH Instance, then no such resource exists, and the renderer gets a `null` and raises that error.

The IG Publisher itself doesn't know that these resources exist inline - all it knows is whatever resources that SUSHI outputs, and if a resource is `#inline` then the SUSHI output contains no such resource. 

## How to fix

If any resource which references other resources has a "Report Details" table (or a similar table) created by the IG Publisher, then for each referenced resource `Usage:` should be set to `#example` rather than `#inline`. 

## Avoiding in future

I think a SUSHI config option to raise a warning/error if a referenced resource does not exist would catch this sooner, and enable developers to more-easily narrow down where the error occurs. Currently, SUSHI will compile references which do not correspond to existing resources.