### PR TITLE
Fix/design

### DIFF
--- a/design/pft-example-typescript/diffusing-capacity/KCO.ts
+++ b/design/pft-example-typescript/diffusing-capacity/KCO.ts
@@ -12,8 +12,8 @@ export const KCO: FHIR.Observation = {
     coding: [
       {
         system: "http://loinc.org",
-        code: "", // TODO
-        display: "",
+        code: "82620-6",
+        display: "Diffusion capacity/Alveolar volume --post bronchodilation",
       },
     ],
     text: "KCO (mL/min/mmHg/L)",

--- a/design/pft-example-typescript/diffusing-capacity/TLC_sb.ts
+++ b/design/pft-example-typescript/diffusing-capacity/TLC_sb.ts
@@ -1,4 +1,4 @@
-/** @fileoverview TLC_sb (Total Lung Volume, single breath) Observation: Liters */
+/** @fileoverview TLC_sb (Total Lung Capacity, single breath) Observation: Liters */
 
 import FHIR from '@automate-medical/fhir-schema-types';
 

--- a/design/pft-example-typescript/diffusing-capacity/VA.ts
+++ b/design/pft-example-typescript/diffusing-capacity/VA.ts
@@ -12,9 +12,9 @@ export const VA_L: FHIR.Observation = {
   code: {
     coding: [
       {
-        system: "http://loinc.org",
-        code: "",
-        display: "",
+        system: "http://snomed.info/sct",
+        code: "251953007",
+        display: "Alveolar volume (observable entity)",
       },
     ],
     text: "V_A (L)",

--- a/design/pft-example-typescript/diffusing-capacity/VI_over_VC.ts
+++ b/design/pft-example-typescript/diffusing-capacity/VI_over_VC.ts
@@ -1,4 +1,4 @@
-/** @fileoverview V_I / V_C Observation.
+/** @fileoverview V_I / V_C (inspired volume/vital capacity) Observation.
  * 
  * Abbreviations:
  *  - V_I: Inspired volume
@@ -20,8 +20,8 @@ export const VI_over_VC: FHIR.Observation = {
     coding: [
       {
         system: "http://loinc.org",
-        code: "19858-0",
-        display: "Total lung capacity by Helium single breath", // TODO: This is masurement is by helium, right
+        code: "",
+        display: "",
       },
     ],
     text: "V_I / V_L (%)",


### PR DESCRIPTION
Fix of minor errors in the example Typescript definitions. 

A handful of errors I noticed while using these to help create Profiles. Not important now that we've moved to FSH, but thought to commit for sake of correctness.