### PR TITLE
Conform profiles to naming schema

### DIFF
--- a/input/fsh/Profiles/DiagnosticReport.fsh
+++ b/input/fsh/Profiles/DiagnosticReport.fsh
@@ -11,27 +11,29 @@ Description: "Diagnostic report for a pulmonary function test."
 * result ^slicing.discriminator.path = "reference"
 * result ^slicing.rules = #open
 * result contains
-  SPO2_RESTING 0..1 and
+  SPO2AtRest 0..1 and
   ForcedVitalCapacity 0..1 and
   ForcedVitalCapacity_Zscore 0..1 and
-  ForcedVitalCapacity_percentPredicted 0..1 and
-  ForcedVitalCapacity_PreBronchodilator 0..1 and
-  ForcedVitalCapacity_PreBronchodilator_Zscore 0..1 and
-  ForcedVitalCapacity_PreBronchodilator_percentPredicted 0..1 and
-  ForcedVitalCapacity_PostBronchodilator 0..1 and
-  ForcedVitalCapacity_PostBronchodilator_Zscore 0..1 and
-  ForcedVitalCapacity_PostBronchodilator_percentPredicted 0..1 and
-  ForcedVitalCapacity_PostBronchodilator_mLChange 0..1 and
-  ForcedVitalCapacity_PostBronchodilator_percentChange 0..1 and
-  ForcedExpiratoryVolume_1s 0..1 and
-  ForcedExpiratoryVolume_1s_Zscore 0..1 and
-  ForcedExpiratoryVolume_1s_percentPredicted 0..1 and
-  ForcedExpiratoryVolume_1s_PreBronchodilator 0..1 and
-  ForcedExpiratoryVolume_1s_PreBronchodilator_Zscore 0..1 and
-  ForcedExpiratoryVolume_1s_PreBronchodilator_percentPredicted 0..1 and
-  ForcedExpiratoryVolume_1s_PostBronchodilator 0..1 and
-  ForcedExpiratoryVolume_1s_PostBronchodilator_Zscore 0..1 and
-  ForcedExpiratoryVolume_1s_PostBronchodilator_percentPredicted 0..1 and
+  ForcedVitalCapacity_PercentOfPredicted 0..1 and
+  ForcedVitalCapacityPreBronchodilator 0..1 and
+  ForcedVitalCapacityPreBronchodilator_Zscore 0..1 and
+  ForcedVitalCapacityPreBronchodilator_PercentOfPredicted 0..1 and
+  ForcedVitalCapacityPostBronchodilator 0..1 and
+  ForcedVitalCapacityPostBronchodilator_Zscore 0..1 and
+  ForcedVitalCapacityPostBronchodilator_PercentOfPredicted 0..1 and
+  ForcedVitalCapacityPostBronchodilator_mLChange 0..1 and
+  ForcedVitalCapacityPostBronchodilator_PercentChange 0..1 and
+  ForcedExpiratoryVolume1Sec 0..1 and
+  ForcedExpiratoryVolume1Sec_Zscore 0..1 and
+  ForcedExpiratoryVolume1Sec_PercentOfPredicted 0..1 and
+  ForcedExpiratoryVolume1SecPreBronchodilator 0..1 and
+  ForcedExpiratoryVolume1SecPreBronchodilator_Zscore 0..1 and
+  ForcedExpiratoryVolume1SecPreBronchodilator_PercentOfPredicted 0..1 and
+  ForcedExpiratoryVolume1SecPostbronchodilator 0..1 and
+  ForcedExpiratoryVolume1SecPostbronchodilator_Zscore 0..1 and
+  ForcedExpiratoryVolume1SecPostbronchodilator_PercentOfPredicted 0..1 and
+  ForcedExpiratoryVolume1SecPostbronchodilator_mLChange 0..1 and
+  ForcedExpiratoryVolume1SecPostbronchodilator_PercentChange 0..1 and
   FEV1_over_FVC 0..1 and
   FEV1_over_FVC_Zscore 0..1 and
   FEV1_over_FVC_PreBronchodilator 0..1 and
@@ -39,50 +41,51 @@ Description: "Diagnostic report for a pulmonary function test."
   FEV1_over_FVC_PostBronchodilator 0..1 and
   FEV1_over_FVC_PostBronchodilator_Zscore 0..1 and
   ForcedExpiratoryTime 0..1 and
-  ForcedExpiratoryTime_PreBronchodilator 0..1 and
-  ForcedExpiratoryTime_PostBronchodilator 0..1 and
+  ForcedExpiratoryTimePreBronchodilator 0..1 and
+  ForcedExpiratoryTimePostBronchodilator 0..1 and
   DLCO 0..1 and
-  DLCO_atStandardPb 0..1 and
-  DLCO_atStandardPb_Zscore 0..1 and
-  DLCO_atStandardPb_percentPredicted 0..1 and
-  DLCO_predAdjHb 0..1 and
-  DLCO_predAdjHb_percentPredicted 0..1 and
+  DLCOAtStandardBarometricPressure 0..1 and
+  DLCOAtStandardBarometricPressure_Zscore 0..1 and
+  DLCOAtStandardBarometricPressure_PercentOfPredicted 0..1 and
+  DLCOAdjustedForHemoglobin 0..1 and
+  DLCOAdjustedForHemoglobin_PercentOfPredicted 0..1 and
   AlveolarVolume 0..1 and
   AlveolarVolume_Zscore 0..1 and
-  AlveolarVolume_percentPredicted 0..1 and
+  AlveolarVolume_PercentOfPredicted 0..1 and
   TotalLungCapacityByHeliumSingleBreath 0..1 and
   VI_over_VC 0..1 and
-  CarbonMonoxideTransferCoefficient 0..1 and
-  CarbonMonoxideTransferCoefficient_Zscore 0..1 and
-  CarbonMonoxideTransferCoefficient_percentPredicted 0..1 and
-  CarbonMonoxideTransferCoefficient_PreBronchodilator 0..1 and
-  CarbonMonoxideTransferCoefficient_PreBronchodilator_Zscore 0..1 and
-  CarbonMonoxideTransferCoefficient_PreBronchodilator_percentPredicted 0..1 and
-  CarbonMonoxideTransferCoefficient_PostBronchodilator 0..1 and
-  CarbonMonoxideTransferCoefficient_PostBronchodilator_Zscore 0..1 and
-  CarbonMonoxideTransferCoefficient_PostBronchodilator_percentPredicted 0..1
-* result[SPO2_RESTING] only Reference(SPO2_RESTING)
+  KCO 0..1 and
+  KCO_Zscore 0..1 and
+  KCO_PercentOfPredicted 0..1 and
+  KCOPreBronchodilator 0..1 and
+  KCOPreBronchodilator_Zscore 0..1 and
+  KCOPreBronchodilator_PercentOfPredicted 0..1 and
+  KCOPostBronchodilator 0..1 and
+  KCOPostBronchodilator_Zscore 0..1 and
+  KCOPostBronchodilator_PercentOfPredicted 0..1
+* result[SPO2AtRest] only Reference(SPO2AtRest)
 * result[ForcedVitalCapacity] only Reference(ForcedVitalCapacity)
 * result[ForcedVitalCapacity_Zscore] only Reference(ForcedVitalCapacity_Zscore)
-* result[ForcedVitalCapacity_percentPredicted] only Reference(ForcedVitalCapacity_percentPredicted)
-* result[ForcedVitalCapacity_PreBronchodilator] only Reference(ForcedVitalCapacity_PreBronchodilator)
-* result[ForcedVitalCapacity_PreBronchodilator] only Reference(ForcedVitalCapacity_PreBronchodilator)
-* result[ForcedVitalCapacity_PreBronchodilator_Zscore] only Reference(ForcedVitalCapacity_PreBronchodilator_Zscore)
-* result[ForcedVitalCapacity_PreBronchodilator_percentPredicted] only Reference(ForcedVitalCapacity_PreBronchodilator_percentPredicted)
-* result[ForcedVitalCapacity_PostBronchodilator] only Reference(ForcedVitalCapacity_PostBronchodilator)
-* result[ForcedVitalCapacity_PostBronchodilator_Zscore] only Reference(ForcedVitalCapacity_PostBronchodilator_Zscore)
-* result[ForcedVitalCapacity_PostBronchodilator_percentPredicted] only Reference(ForcedVitalCapacity_PostBronchodilator_percentPredicted)
-* result[ForcedVitalCapacity_PostBronchodilator_mLChange] only Reference(ForcedVitalCapacity_PostBronchodilator_mLChange)
-* result[ForcedVitalCapacity_PostBronchodilator_percentChange] only Reference(ForcedVitalCapacity_PostBronchodilator_percentChange)
-* result[ForcedExpiratoryVolume_1s] only Reference(ForcedExpiratoryVolume_1s)
-* result[ForcedExpiratoryVolume_1s_Zscore] only Reference(ForcedExpiratoryVolume_1s_Zscore)
-* result[ForcedExpiratoryVolume_1s_percentPredicted] only Reference(ForcedExpiratoryVolume_1s_percentPredicted)
-* result[ForcedExpiratoryVolume_1s_PreBronchodilator] only Reference(ForcedExpiratoryVolume_1s_PreBronchodilator)
-* result[ForcedExpiratoryVolume_1s_PreBronchodilator_Zscore] only Reference(ForcedExpiratoryVolume_1s_PreBronchodilator_Zscore)
-* result[ForcedExpiratoryVolume_1s_PreBronchodilator_percentPredicted] only Reference(ForcedExpiratoryVolume_1s_PreBronchodilator_percentPredicted)
-* result[ForcedExpiratoryVolume_1s_PostBronchodilator] only Reference(ForcedExpiratoryVolume_1s_PostBronchodilator)
-* result[ForcedExpiratoryVolume_1s_PostBronchodilator_Zscore] only Reference(ForcedExpiratoryVolume_1s_PostBronchodilator_Zscore)
-* result[ForcedExpiratoryVolume_1s_PostBronchodilator_percentPredicted] only Reference(ForcedExpiratoryVolume_1s_PostBronchodilator_percentPredicted)
+* result[ForcedVitalCapacity_PercentOfPredicted] only Reference(ForcedVitalCapacity_PercentOfPredicted)
+* result[ForcedVitalCapacityPreBronchodilator] only Reference(ForcedVitalCapacityPreBronchodilator)
+* result[ForcedVitalCapacityPreBronchodilator_Zscore] only Reference(ForcedVitalCapacityPreBronchodilator_Zscore)
+* result[ForcedVitalCapacityPreBronchodilator_PercentOfPredicted] only Reference(ForcedVitalCapacityPreBronchodilator_PercentOfPredicted)
+* result[ForcedVitalCapacityPostBronchodilator] only Reference(ForcedVitalCapacityPostBronchodilator)
+* result[ForcedVitalCapacityPostBronchodilator_Zscore] only Reference(ForcedVitalCapacityPostBronchodilator_Zscore)
+* result[ForcedVitalCapacityPostBronchodilator_PercentOfPredicted] only Reference(ForcedVitalCapacityPostBronchodilator_PercentOfPredicted)
+* result[ForcedVitalCapacityPostBronchodilator_mLChange] only Reference(ForcedVitalCapacityPostBronchodilator_mLChange)
+* result[ForcedVitalCapacityPostBronchodilator_PercentChange] only Reference(ForcedVitalCapacityPostBronchodilator_PercentChange)
+* result[ForcedExpiratoryVolume1Sec] only Reference(ForcedExpiratoryVolume1Sec)
+* result[ForcedExpiratoryVolume1Sec_Zscore] only Reference(ForcedExpiratoryVolume1Sec_Zscore)
+* result[ForcedExpiratoryVolume1Sec_PercentOfPredicted] only Reference(ForcedExpiratoryVolume1Sec_PercentOfPredicted)
+* result[ForcedExpiratoryVolume1SecPreBronchodilator] only Reference(ForcedExpiratoryVolume1SecPreBronchodilator)
+* result[ForcedExpiratoryVolume1SecPreBronchodilator_Zscore] only Reference(ForcedExpiratoryVolume1SecPreBronchodilator_Zscore)
+* result[ForcedExpiratoryVolume1SecPreBronchodilator_PercentOfPredicted] only Reference(ForcedExpiratoryVolume1SecPreBronchodilator_PercentOfPredicted)
+* result[ForcedExpiratoryVolume1SecPostbronchodilator] only Reference(ForcedExpiratoryVolume1SecPostbronchodilator)
+* result[ForcedExpiratoryVolume1SecPostbronchodilator_Zscore] only Reference(ForcedExpiratoryVolume1SecPostbronchodilator_Zscore)
+* result[ForcedExpiratoryVolume1SecPostbronchodilator_PercentOfPredicted] only Reference(ForcedExpiratoryVolume1SecPostbronchodilator_PercentOfPredicted)
+* result[ForcedExpiratoryVolume1SecPostbronchodilator_mLChange] only Reference(ForcedExpiratoryVolume1SecPostbronchodilator_mLChange)
+* result[ForcedExpiratoryVolume1SecPostbronchodilator_PercentChange] only Reference(ForcedExpiratoryVolume1SecPostbronchodilator_PercentChange)
 * result[FEV1_over_FVC] only Reference(FEV1_over_FVC)
 * result[FEV1_over_FVC_Zscore] only Reference(FEV1_over_FVC_Zscore)
 * result[FEV1_over_FVC_PreBronchodilator] only Reference(FEV1_over_FVC_PreBronchodilator)
@@ -90,25 +93,25 @@ Description: "Diagnostic report for a pulmonary function test."
 * result[FEV1_over_FVC_PostBronchodilator] only Reference(FEV1_over_FVC_PostBronchodilator)
 * result[FEV1_over_FVC_PostBronchodilator_Zscore] only Reference(FEV1_over_FVC_PostBronchodilator_Zscore)
 * result[ForcedExpiratoryTime] only Reference(ForcedExpiratoryTime)
-* result[ForcedExpiratoryTime_PreBronchodilator] only Reference(ForcedExpiratoryTime_PreBronchodilator)
-* result[ForcedExpiratoryTime_PostBronchodilator] only Reference(ForcedExpiratoryTime_PostBronchodilator)
+* result[ForcedExpiratoryTimePreBronchodilator] only Reference(ForcedExpiratoryTimePreBronchodilator)
+* result[ForcedExpiratoryTimePostBronchodilator] only Reference(ForcedExpiratoryTimePostBronchodilator)
 * result[DLCO] only Reference(DLCO)
-* result[DLCO_atStandardPb] only Reference(DLCO_atStandardPb)
-* result[DLCO_atStandardPb_Zscore] only Reference(DLCO_atStandardPb_Zscore)
-* result[DLCO_atStandardPb_percentPredicted] only Reference(DLCO_atStandardPb_percentPredicted)
-* result[DLCO_predAdjHb] only Reference(DLCO_predAdjHb)
-* result[DLCO_predAdjHb_percentPredicted] only Reference(DLCO_predAdjHb_percentPredicted)
+* result[DLCOAtStandardBarometricPressure] only Reference(DLCOAtStandardBarometricPressure)
+* result[DLCOAtStandardBarometricPressure_Zscore] only Reference(DLCOAtStandardBarometricPressure_Zscore)
+* result[DLCOAtStandardBarometricPressure_PercentOfPredicted] only Reference(DLCOAtStandardBarometricPressure_PercentOfPredicted)
+* result[DLCOAdjustedForHemoglobin] only Reference(DLCOAdjustedForHemoglobin)
+* result[DLCOAdjustedForHemoglobin_PercentOfPredicted] only Reference(DLCOAdjustedForHemoglobin_PercentOfPredicted)
 * result[AlveolarVolume] only Reference(AlveolarVolume)
 * result[AlveolarVolume_Zscore] only Reference(AlveolarVolume_Zscore)
-* result[AlveolarVolume_percentPredicted] only Reference(AlveolarVolume_percentPredicted)
+* result[AlveolarVolume_PercentOfPredicted] only Reference(AlveolarVolume_PercentOfPredicted)
 * result[TotalLungCapacityByHeliumSingleBreath] only Reference(TotalLungCapacityByHeliumSingleBreath)
 * result[VI_over_VC] only Reference(VI_over_VC)
-* result[CarbonMonoxideTransferCoefficient] only Reference(CarbonMonoxideTransferCoefficient)
-* result[CarbonMonoxideTransferCoefficient_Zscore] only Reference(CarbonMonoxideTransferCoefficient_Zscore)
-* result[CarbonMonoxideTransferCoefficient_percentPredicted] only Reference(CarbonMonoxideTransferCoefficient_percentPredicted)
-* result[CarbonMonoxideTransferCoefficient_PreBronchodilator] only Reference(CarbonMonoxideTransferCoefficient_PreBronchodilator)
-* result[CarbonMonoxideTransferCoefficient_PreBronchodilator_Zscore] only Reference(CarbonMonoxideTransferCoefficient_PreBronchodilator_Zscore)
-* result[CarbonMonoxideTransferCoefficient_PreBronchodilator_percentPredicted] only Reference(CarbonMonoxideTransferCoefficient_PreBronchodilator_percentPredicted)
-* result[CarbonMonoxideTransferCoefficient_PostBronchodilator] only Reference(CarbonMonoxideTransferCoefficient_PostBronchodilator)
-* result[CarbonMonoxideTransferCoefficient_PostBronchodilator_Zscore] only Reference(CarbonMonoxideTransferCoefficient_PostBronchodilator_Zscore)
-* result[CarbonMonoxideTransferCoefficient_PostBronchodilator_percentPredicted] only Reference(CarbonMonoxideTransferCoefficient_PostBronchodilator_percentPredicted)
+* result[KCO] only Reference(KCO)
+* result[KCO_Zscore] only Reference(KCO_Zscore)
+* result[KCO_PercentOfPredicted] only Reference(KCO_PercentOfPredicted)
+* result[KCOPreBronchodilator] only Reference(KCOPreBronchodilator)
+* result[KCOPreBronchodilator_Zscore] only Reference(KCOPreBronchodilator_Zscore)
+* result[KCOPreBronchodilator_PercentOfPredicted] only Reference(KCOPreBronchodilator_PercentOfPredicted)
+* result[KCOPostBronchodilator] only Reference(KCOPostBronchodilator)
+* result[KCOPostBronchodilator_Zscore] only Reference(KCOPostBronchodilator_Zscore)
+* result[KCOPostBronchodilator_PercentOfPredicted] only Reference(KCOPostBronchodilator_PercentOfPredicted)

--- a/input/fsh/Profiles/DiagnosticReport.fsh
+++ b/input/fsh/Profiles/DiagnosticReport.fsh
@@ -2,8 +2,8 @@
 
 Profile:     PFT_DiagnosticReport
 Parent:      DiagnosticReport
-Id:          PFT-DiagnosticReport
-Title:       "PFT DiagnosticReport"
+Id:          PulmonaryFunctionTestDiagnosticReport
+Title:       "Pulmonary Function Test (PFT) Diagnostic Report"
 Description: "Diagnostic report for a pulmonary function test."
 * category = http://terminology.hl7.org/CodeSystem/v2-0074#PF "Pulmonary Function"
 * code = $LNC#81458-2 "Pulmonary function test panel"

--- a/input/fsh/Profiles/SPO2_RESTING.fsh
+++ b/input/fsh/Profiles/SPO2_RESTING.fsh
@@ -1,4 +1,4 @@
-Profile: SPO2_RESTING
+Profile: SPO2AtRest
 Parent: Observation
 Id: SPO2AtRest
 Title: "SpO2 at rest"

--- a/input/fsh/Profiles/SPO2_RESTING.fsh
+++ b/input/fsh/Profiles/SPO2_RESTING.fsh
@@ -1,6 +1,6 @@
 Profile: SPO2_RESTING
 Parent: Observation
-Id: SPO2-RESTING
+Id: SPO2AtRest
 Title: "SpO2 at rest"
 Description: "A resting SpO2 measurement."
 * code = $LNC#59417-6 "Oxygen saturation in Arterial blood by Pulse oximetry --resting"

--- a/input/fsh/Profiles/SPO2_RESTING.fsh
+++ b/input/fsh/Profiles/SPO2_RESTING.fsh
@@ -2,7 +2,7 @@ Profile: SPO2_RESTING
 Parent: Observation
 Id: SPO2AtRest
 Title: "SpO2 at rest"
-Description: "A resting SpO2 measurement."
+Description: "A measurement of oxygen saturation in arterial blood taken by pulse oximetry, with the patient at rest."
 * code = $LNC#59417-6 "Oxygen saturation in Arterial blood by Pulse oximetry --resting"
 * valueQuantity
   * unit = "%"

--- a/input/fsh/Profiles/diffusing-capacity/AlveolarVolume.fsh
+++ b/input/fsh/Profiles/diffusing-capacity/AlveolarVolume.fsh
@@ -26,7 +26,7 @@ Description: "The z-score of an alveolar volume measurement, calculated from som
   * system = $UCUM
   * code = #{Zscore}
 
-Profile: AlveolarVolume_percentPredicted
+Profile: AlveolarVolume_PercentOfPredicted
 Parent: Observation
 Id: AlveolarVolume-PercentOfPredicted
 Title: "Alveolar Volume (VA) Percent Of Predicted"

--- a/input/fsh/Profiles/diffusing-capacity/AlveolarVolume.fsh
+++ b/input/fsh/Profiles/diffusing-capacity/AlveolarVolume.fsh
@@ -4,7 +4,7 @@
 Profile: AlveolarVolume
 Parent: Observation
 Id: AlveolarVolume
-Title: "AlveolarVolume"
+Title: "Alveolar Volume (VA)"
 Description: "A measurement of alveolar volume, in liters."
 * code = $SCT#251953007 "Alveolar volume (observable entity)"
 * value[x] only Quantity
@@ -16,7 +16,7 @@ Description: "A measurement of alveolar volume, in liters."
 Profile: AlveolarVolume_Zscore
 Parent: Observation
 Id: AlveolarVolume-Zscore
-Title: "AlveolarVolume_Zscore"
+Title: "Alveolar Volume (VA) Zscore"
 Description: "The z-score of an alveolar volume measurement, calculated from some reference distribution."
 * code
   * text = "Alveolar volume (z-score)"
@@ -28,8 +28,8 @@ Description: "The z-score of an alveolar volume measurement, calculated from som
 
 Profile: AlveolarVolume_percentPredicted
 Parent: Observation
-Id: AlveolarVolume-percentPredcted
-Title: "AlveolarVolume_percentPredicted"
+Id: AlveolarVolume-PercentOfPredicted
+Title: "Alveolar Volume (VA) Percent Of Predicted"
 Description: "An alveolar volume measurement as the percentage of some predicted reference value."
 * code
   * text = "Alveolar volume measured/predicted"

--- a/input/fsh/Profiles/diffusing-capacity/DLCO.fsh
+++ b/input/fsh/Profiles/diffusing-capacity/DLCO.fsh
@@ -20,7 +20,7 @@ Description: "Diffusion capacity of lung for carbon monoxide."
 /*
  * DLCO at standard P_B (barometric pressure)
  */
-Profile: DLCO_atStandardPb
+Profile: DLCOAtStandardBarometricPressure
 Parent: Observation
 Id: DLCOAtStandardBarometricPressure
 Title: "Diffusion Capacity Of Lung For Carbon Monoxide (DLCO) At Standard Barometric Pressure (PB)"
@@ -33,7 +33,7 @@ Description: "Diffusion capacity of lung for carbon monoxide at standard baromet
   * system = $UCUM
   * code = #mL/min/mmHg
 
-Profile: DLCO_atStandardPb_Zscore
+Profile: DLCOAtStandardBarometricPressure_Zscore
 Parent: Observation
 Id: DLCOAtStandardBarometricPressure-Zscore
 Title: "Diffusion Capacity Of Lung For Carbon Monoxide (DLCO) At Standard Barometric Pressure (PB) Zscore"
@@ -46,7 +46,7 @@ Description: "Diffusion capacity of lung for carbon monoxide at standard baromet
   * system = $UCUM
   * code = #{Zscore}
 
-Profile: DLCO_atStandardPb_percentPredicted
+Profile: DLCOAtStandardBarometricPressure_PercentOfPredicted
 Parent: Observation
 Id: DLCOAtStandardBarometricPressure-PercentOfPredicted
 Title: "Diffusion Capacity Of Lung For Carbon Monoxide (DLCO) At Standard Barometric Pressure (PB) Percent Of Predicted"
@@ -62,7 +62,7 @@ Description: "Diffusion capacity of lung for carbon monoxide at standard baromet
 /*
  * DLCO adjusted for H_b (hemoglobin)
  */
-Profile: DLCO_predAdjHb
+Profile: DLCOAdjustedForHemoglobin
 Parent: Observation
 Id: DLCOAdjustedForHemoglobin
 Title: "Diffusion Capacity Of Lung For Carbon Monoxide (DLCO) Adjusted For Hemoglobin (Hb)"
@@ -74,7 +74,7 @@ Description: "Diffusion capacity of lung for carbon monoxide, adjusted for hemog
   * system = $UCUM
   * code = #mL/min/mmHg
 
-Profile: DLCO_predAdjHb_percentPredicted
+Profile: DLCOAdjustedForHemoglobin_PercentOfPredicted
 Parent: Observation
 Id: DLCOAdjustedForHemoglobin-PercentOfPredicted
 Title: "Diffusion Capacity Of Lung For Carbon Monoxide (DLCO) Adjusted For Hemoglobin (Hb) Percent Of Predicted"

--- a/input/fsh/Profiles/diffusing-capacity/DLCO.fsh
+++ b/input/fsh/Profiles/diffusing-capacity/DLCO.fsh
@@ -7,7 +7,7 @@
 Profile: DLCO
 Parent: Observation
 Id: DLCO
-Title: "DLCO"
+Title: "Diffusion Capacity Of Lung For Carbon Monoxide (DLCO)"
 Description: "Diffusion capacity of lung for carbon monoxide."
 * code = $LNC#19911-7 "Diffusion capacity.carbon monoxide"
 * value[x] only Quantity
@@ -18,12 +18,12 @@ Description: "Diffusion capacity of lung for carbon monoxide."
 
 
 /*
- * DLCO at standard P_b (barometric pressure)
+ * DLCO at standard P_B (barometric pressure)
  */
 Profile: DLCO_atStandardPb
 Parent: Observation
-Id: DLCO-atStandardPb
-Title: "DLCO_atStandardPb"
+Id: DLCOAtStandardBarometricPressure
+Title: "Diffusion Capacity Of Lung For Carbon Monoxide (DLCO) At Standard Barometric Pressure (PB)"
 Description: "Diffusion capacity of lung for carbon monoxide at standard barometric pressure."
 * code
   * text = "Diffusion capacity of lung for carbon monoxide at standard barometric pressure"
@@ -35,8 +35,8 @@ Description: "Diffusion capacity of lung for carbon monoxide at standard baromet
 
 Profile: DLCO_atStandardPb_Zscore
 Parent: Observation
-Id: DLCO-atStandardPb-Zscore
-Title: "DLCO_atStandardPb_Zscore"
+Id: DLCOAtStandardBarometricPressure-Zscore
+Title: "Diffusion Capacity Of Lung For Carbon Monoxide (DLCO) At Standard Barometric Pressure (PB) Zscore"
 Description: "Diffusion capacity of lung for carbon monoxide at standard barometric pressure (z-score)."
 * code
   * text = "Diffusion capacity of lung for carbon monoxide at standard barometric pressure (z-score)"
@@ -48,8 +48,8 @@ Description: "Diffusion capacity of lung for carbon monoxide at standard baromet
 
 Profile: DLCO_atStandardPb_percentPredicted
 Parent: Observation
-Id: DLCO-atStandardPb-percentPredicted
-Title: "DLCO_atStandardPb_percentPredicted"
+Id: DLCOAtStandardBarometricPressure-PercentOfPredicted
+Title: "Diffusion Capacity Of Lung For Carbon Monoxide (DLCO) At Standard Barometric Pressure (PB) Percent Of Predicted"
 Description: "Diffusion capacity of lung for carbon monoxide at standard barometric pressure (% of predicted)."
 * code
   * text = "Diffusion capacity of lung for carbon monoxide at standard barometric pressure (% of predicted)"
@@ -64,8 +64,8 @@ Description: "Diffusion capacity of lung for carbon monoxide at standard baromet
  */
 Profile: DLCO_predAdjHb
 Parent: Observation
-Id: DLCO-predAdjHb
-Title: "DLCO_predAdjHb"
+Id: DLCOAdjustedForHemoglobin
+Title: "Diffusion Capacity Of Lung For Carbon Monoxide (DLCO) Adjusted For Hemoglobin (Hb)"
 Description: "Diffusion capacity of lung for carbon monoxide, adjusted for hemoglobin."
 * code = $LNC#19913-3 "Diffusion capacity.carbon monoxide adjusted for hemoglobin"
 * value[x] only Quantity
@@ -76,8 +76,8 @@ Description: "Diffusion capacity of lung for carbon monoxide, adjusted for hemog
 
 Profile: DLCO_predAdjHb_percentPredicted
 Parent: Observation
-Id: DLCO-predAdjHb-percentPredicted
-Title: "DLCO_predAdjHb_percentPredicted"
+Id: DLCOAdjustedForHemoglobin-PercentOfPredicted
+Title: "Diffusion Capacity Of Lung For Carbon Monoxide (DLCO) Adjusted For Hemoglobin (Hb) Percent Of Predicted"
 Description: "Diffusion capacity of lung for carbon monoxide, adjusted for hemoglobin (% of predicted)."
 * code
   * text = "Diffusion capacity.carbon monoxide adjusted for hemoglobin measured/predicted"

--- a/input/fsh/Profiles/diffusing-capacity/KCO.fsh
+++ b/input/fsh/Profiles/diffusing-capacity/KCO.fsh
@@ -4,7 +4,7 @@
 /*
  * Pre- or post-bronchodilator not specified
  */
-Profile: CarbonMonoxideTransferCoefficient
+Profile: KCO
 Parent: Observation
 Id: KCO
 Title: "KCO"
@@ -18,7 +18,7 @@ Also referred to as KCO or DLCO/VA."""
   * system = $UCUM
   * code = #mL/min/mmHg
 
-Profile: CarbonMonoxideTransferCoefficient_Zscore
+Profile: KCO_Zscore
 Parent: Observation
 Id: KCO-Zscore
 Title: "KCO Zscore"
@@ -31,7 +31,7 @@ Description: "The z-score of a carbon monoxide transfer coefficient measurement,
   * system = $UCUM
   * code = #{Zscore}
 
-Profile: CarbonMonoxideTransferCoefficient_percentPredicted
+Profile: KCO_PercentOfPredicted
 Parent: Observation
 Id: KCO-PercentOfPredicted
 Title: "KCO Percent Of Predicted"
@@ -48,7 +48,7 @@ Description: "A measurement of carbon monoxide transfer coefficient as the perce
 /*
  * Pre-bronchodilator
  */
-Profile: CarbonMonoxideTransferCoefficient_PreBronchodilator
+Profile: KCOPreBronchodilator
 Parent: Observation
 Id: KCOPreBronchodilator
 Title: "KCO Pre-bronchodilator"
@@ -62,7 +62,7 @@ Also referred to as KCO or DLCO/VA."""
   * system = $UCUM
   * code = #mL/min/mmHg
 
-Profile: CarbonMonoxideTransferCoefficient_PreBronchodilator_Zscore
+Profile: KCOPreBronchodilator_Zscore
 Parent: Observation
 Id: KCOPreBronchodilator-Zscore
 Title: "KCO Pre-bronchodilator Zscore"
@@ -75,7 +75,7 @@ Description: "Carbon monoxide transfer coefficient pre-bronchodilator z-score. N
   * system = $UCUM
   * code = #{Zscore}
 
-Profile: CarbonMonoxideTransferCoefficient_PreBronchodilator_percentPredicted
+Profile: KCOPreBronchodilator_PercentOfPredicted
 Parent: Observation
 Id: KCOPreBronchodilator-PercentOfPredicted
 Title: "KCO Pre-bronchodilator Percent Of Predicted"
@@ -91,7 +91,7 @@ Description: "Carbon monoxide transfer coefficient (% predicted), pre-bronchodil
 /*
  * Post-bronchodilator
  */
-Profile: CarbonMonoxideTransferCoefficient_PostBronchodilator
+Profile: KCOPostBronchodilator
 Parent: Observation
 Id: KCOPostBronchodilator
 Title: "KCO Post-bronchodilator"
@@ -104,7 +104,7 @@ Description: "Carbon monoxide transfer coefficient, post-bronchodilator. Note: a
   * code = #mL/min/mmHg
 
 
-Profile: CarbonMonoxideTransferCoefficient_PostBronchodilator_Zscore
+Profile: KCOPostBronchodilator_Zscore
 Parent: Observation
 Id: KCOPostBronchodilator-Zscore
 Title: "KCO Post-bronchodilator Zscore"
@@ -117,7 +117,7 @@ Description: "Carbon monoxide transfer coefficient post-bronchodilator z-score. 
   * system = $UCUM
   * code = #{Zscore}
 
-Profile: CarbonMonoxideTransferCoefficient_PostBronchodilator_percentPredicted
+Profile: KCOPostBronchodilator_PercentOfPredicted
 Parent: Observation
 Id: KCOPostBronchodilator-PercentOfPredicted
 Title: "KCO Post-bronchodilator Percent Of Predicted"

--- a/input/fsh/Profiles/diffusing-capacity/KCO.fsh
+++ b/input/fsh/Profiles/diffusing-capacity/KCO.fsh
@@ -21,7 +21,7 @@ Also referred to as KCO or DLCO/VA."""
 Profile: CarbonMonoxideTransferCoefficient_Zscore
 Parent: Observation
 Id: KCO-Zscore
-Title: "KCO_Zscore"
+Title: "KCO Zscore"
 Description: "The z-score of a carbon monoxide transfer coefficient measurement, calculated from some reference distribution."
 * code
   * text = "Diffusion capacity/Alveolar volume (z-score)"
@@ -33,8 +33,8 @@ Description: "The z-score of a carbon monoxide transfer coefficient measurement,
 
 Profile: CarbonMonoxideTransferCoefficient_percentPredicted
 Parent: Observation
-Id: KCO-percentPredicted
-Title: "KCO"
+Id: KCO-PercentOfPredicted
+Title: "KCO Percent Of Predicted"
 Description: "A measurement of carbon monoxide transfer coefficient as the percentage of some predicted reference value."
 * code
   * text = "Diffusion capacity/Alveolar volume (measured/predicted)"
@@ -50,8 +50,8 @@ Description: "A measurement of carbon monoxide transfer coefficient as the perce
  */
 Profile: CarbonMonoxideTransferCoefficient_PreBronchodilator
 Parent: Observation
-Id: KCO-PRE
-Title: "KCO_PRE"
+Id: KCOPreBronchodilator
+Title: "KCO Pre-bronchodilator"
 Description: """A measurement of carbon monoxide transfer coefficient pre-bronchodilation, in mL/min/mmHg.
 
 Also referred to as KCO or DLCO/VA."""
@@ -64,8 +64,8 @@ Also referred to as KCO or DLCO/VA."""
 
 Profile: CarbonMonoxideTransferCoefficient_PreBronchodilator_Zscore
 Parent: Observation
-Id: KCO-PRE-Zscore
-Title: "KCO_PRE_Zscore"
+Id: KCOPreBronchodilator-Zscore
+Title: "KCO Pre-bronchodilator Zscore"
 Description: "Carbon monoxide transfer coefficient pre-bronchodilator z-score. Note: also known as KCO or DLCO/VA."
 * code
   * text = "Diffusion capacity/Alveolar volume (z-score) pre-bronchodilator"
@@ -77,8 +77,8 @@ Description: "Carbon monoxide transfer coefficient pre-bronchodilator z-score. N
 
 Profile: CarbonMonoxideTransferCoefficient_PreBronchodilator_percentPredicted
 Parent: Observation
-Id: KCO-PRE-percentPredicted
-Title: "KCO_PRE_percentPredicted"
+Id: KCOPreBronchodilator-PercentOfPredicted
+Title: "KCO Pre-bronchodilator Percent Of Predicted"
 Description: "Carbon monoxide transfer coefficient (% predicted), pre-bronchodilator. Note: also known as KCO or DLCO/VA."
 * code
   * text = "Diffusion capacity/Alveolar volume (measured/predicted) pre-bronchodilator"
@@ -93,8 +93,8 @@ Description: "Carbon monoxide transfer coefficient (% predicted), pre-bronchodil
  */
 Profile: CarbonMonoxideTransferCoefficient_PostBronchodilator
 Parent: Observation
-Id: KCO-POST
-Title: "KCO_POST"
+Id: KCOPostBronchodilator
+Title: "KCO Post-bronchodilator"
 Description: "Carbon monoxide transfer coefficient, post-bronchodilator. Note: also known as KCO or DLCO/VA."
 * code = $LNC#82620-6	"Diffusion capacity/Alveolar volume --post bronchodilation"
 * value[x] only Quantity
@@ -106,8 +106,8 @@ Description: "Carbon monoxide transfer coefficient, post-bronchodilator. Note: a
 
 Profile: CarbonMonoxideTransferCoefficient_PostBronchodilator_Zscore
 Parent: Observation
-Id: KCO-POST-Zscore
-Title: "KCO_POST_Zscore"
+Id: KCOPostBronchodilator-Zscore
+Title: "KCO Post-bronchodilator Zscore"
 Description: "Carbon monoxide transfer coefficient post-bronchodilator z-score. Note: also known as KCO or DLCO/VA."
 * code
   * text = "Diffusion capacity/Alveolar volume (z-score) post-bronchodilator"
@@ -119,8 +119,8 @@ Description: "Carbon monoxide transfer coefficient post-bronchodilator z-score. 
 
 Profile: CarbonMonoxideTransferCoefficient_PostBronchodilator_percentPredicted
 Parent: Observation
-Id: KCO-POST-percentPredicted
-Title: "KCO_POST_percentPredicted"
+Id: KCOPostBronchodilator-PercentOfPredicted
+Title: "KCO Post-bronchodilator Percent Of Predicted"
 Description: "Carbon monoxide transfer coefficient (% predicted), post-bronchodilator. Note: also known as KCO or DLCO/VA."
 * code
   * text = "Diffusion capacity/Alveolar volume (measured/predicted) pre-bronchodilator"

--- a/input/fsh/Profiles/diffusing-capacity/TotalLungCapacityByHeliumSingleBreath.fsh
+++ b/input/fsh/Profiles/diffusing-capacity/TotalLungCapacityByHeliumSingleBreath.fsh
@@ -2,7 +2,7 @@
 Profile: TotalLungCapacityByHeliumSingleBreath
 Parent: Observation
 Id: TotalLungCapacityByHeliumSingleBreath
-Title: "TotalLungCapacityByHeliumSingleBreath"
+Title: "Total Lung Capacity By Helium Single Breath (TLC_sb)"
 Description: "A measurement of total lung capacity by helium, single breath, in liters."
 * code = $LNC#19858-0 "Total lung capacity by Helium single breath"
 * value[x] only Quantity

--- a/input/fsh/Profiles/diffusing-capacity/VI_over_VC.fsh
+++ b/input/fsh/Profiles/diffusing-capacity/VI_over_VC.fsh
@@ -2,7 +2,7 @@
 Profile: VI_over_VC
 Parent: Observation
 Id: VI-over-VC
-Title: "VI_over_VC"
+Title: "VI/VC"
 Description: "Inspired volume (V_I) as a percentage of vital capacity (V_C)."
 * code
   * text = "VI/VC"

--- a/input/fsh/Profiles/spirometry/FET.fsh
+++ b/input/fsh/Profiles/spirometry/FET.fsh
@@ -6,8 +6,8 @@
  */
 Profile: ForcedExpiratoryTime
 Parent: Observation
-Id: FET
-Title: "FET"
+Id: ForcedExpiratoryTime
+Title: "Forced Expiratory Time (FET)"
 Description: "Forced expiratory time (seconds)"
 * code = $LNC#65819-5 "Forced expiratory time"
 * value[x] only Quantity
@@ -22,8 +22,8 @@ Description: "Forced expiratory time (seconds)"
  */
 Profile: ForcedExpiratoryTime_PreBronchodilator
 Parent: Observation
-Id: FET-PRE
-Title: "FET_PRE"
+Id: ForcedExpiratoryTime-PreBronchodilator
+Title: "Forced Expiratory Time (FET) Pre-bronchodilator"
 Description: "Forced expiratory time (seconds) pre-bronchodilator"
 * code
   * coding = $LNC#65819-5 "Forced expiratory time"
@@ -39,8 +39,8 @@ Description: "Forced expiratory time (seconds) pre-bronchodilator"
  */
 Profile: ForcedExpiratoryTime_PostBronchodilator
 Parent: Observation
-Id: FET-POST
-Title: "FET_POST"
+Id: ForcedExpiratoryTime-PostBronchodilator
+Title: "Forced Expiratory Time (FET) Post-bronchodilator"
 Description: "Forced expiratory time (seconds) post-bronchodilator"
 * code
   * coding = $LNC#65819-5 "Forced expiratory time"

--- a/input/fsh/Profiles/spirometry/FET.fsh
+++ b/input/fsh/Profiles/spirometry/FET.fsh
@@ -20,7 +20,7 @@ Description: "Forced expiratory time (seconds)"
 /*
  * Pre-bronchodilator
  */
-Profile: ForcedExpiratoryTime_PreBronchodilator
+Profile: ForcedExpiratoryTimePreBronchodilator
 Parent: Observation
 Id: ForcedExpiratoryTime-PreBronchodilator
 Title: "Forced Expiratory Time (FET) Pre-bronchodilator"
@@ -37,7 +37,7 @@ Description: "Forced expiratory time (seconds) pre-bronchodilator"
 /*
  * Post-bronchodilator
  */
-Profile: ForcedExpiratoryTime_PostBronchodilator
+Profile: ForcedExpiratoryTimePostBronchodilator
 Parent: Observation
 Id: ForcedExpiratoryTime-PostBronchodilator
 Title: "Forced Expiratory Time (FET) Post-bronchodilator"

--- a/input/fsh/Profiles/spirometry/FEV1.fsh
+++ b/input/fsh/Profiles/spirometry/FEV1.fsh
@@ -6,8 +6,8 @@
  */
 Profile: ForcedExpiratoryVolume_1s
 Parent: Observation
-Id: FEV1
-Title: "Forced expiratory volume in 1 second"
+Id: ForcedExpiratoryVolume1Sec
+Title: "Forced Expiratory Volume In 1 Second (FEV1)"
 Description: "Forced expiratory volume in 1 second"
 * code = $LNC#20150-9 "FEV1"
 * value[x] only Quantity
@@ -18,8 +18,8 @@ Description: "Forced expiratory volume in 1 second"
 
 Profile: ForcedExpiratoryVolume_1s_Zscore
 Parent: Observation
-Id: FEV1-Zscore
-Title: "Forced expiratory volume in 1 second (z-score)"
+Id: ForcedExpiratoryVolume1Sec-Zscore
+Title: "Forced Expiratory Volume In 1 Second (FEV1) Zscore"
 Description: "Forced expiratory volume in 1 second (z-score)"
 * code
   * text = "FEV1 (z-score)"
@@ -31,8 +31,8 @@ Description: "Forced expiratory volume in 1 second (z-score)"
 
 Profile: ForcedExpiratoryVolume_1s_percentPredicted
 Parent: Observation
-Id: FEV1-percentPredicted
-Title: "Forced expiratory volume in 1 second (measured/predicted)"
+Id: ForcedExpiratoryVolume1Sec-PercentOfPredicted
+Title: "Forced Expiratory Volume In 1 Second (FEV1) Percent Of Predicted"
 Description: "Forced expiratory volume in 1 second (% pred)"
 * code = $LNC#20152-5 "FEV1 measured/predicted"
 * value[x] only Quantity
@@ -46,8 +46,8 @@ Description: "Forced expiratory volume in 1 second (% pred)"
  */
 Profile: ForcedExpiratoryVolume_1s_PreBronchodilator
 Parent: Observation
-Id: FEV1-PRE
-Title: "Forced expiratory volume in 1 second pre-bronchodilator"
+Id: ForcedExpiratoryVolume1SecPreBronchodilator
+Title: "Forced Expiratory Volume In 1 Second (FEV1) Pre-bronchodilator"
 Description: "Forced expiratory volume in 1 second pre-bronchodilator"
 * code = $LNC#20157-4 "FEV1 --pre bronchodilation"
 * value[x] only Quantity
@@ -58,8 +58,8 @@ Description: "Forced expiratory volume in 1 second pre-bronchodilator"
 
 Profile: ForcedExpiratoryVolume_1s_PreBronchodilator_Zscore
 Parent: Observation
-Id: FEV1-PRE-Zscore
-Title: "Forced expiratory volume in 1 second pre-bronchodilator (z-score) "
+Id: ForcedExpiratoryVolume1SecPreBronchodilator-Zscore
+Title: "Forced Expiratory Volume In 1 Second (FEV1) Pre-bronchodilator Zscore"
 Description: "Forced expiratory volume in 1 second (z-score) pre-bronchodilator"
 * code
   * text = "FEV1 (z-score) pre-bronchodilator"
@@ -71,8 +71,8 @@ Description: "Forced expiratory volume in 1 second (z-score) pre-bronchodilator"
 
 Profile: ForcedExpiratoryVolume_1s_PreBronchodilator_percentPredicted
 Parent: Observation
-Id: FEV1-PRE-percentPredicted
-Title: "Forced expiratory volume in 1 second pre-bronchodilator (measured/predicted)"
+Id: ForcedExpiratoryVolume1SecPreBronchodilator-PercentOfPredicted
+Title: "Forced Expiratory Volume In 1 Second (FEV1) Pre-bronchodilator Percent Of Predicted"
 Description: "Forced expiratory volume in 1 second (% pred) pre-bronchodilator"
 * code
   * coding = $LNC#20152-5 "FEV1 measured/predicted"
@@ -88,8 +88,8 @@ Description: "Forced expiratory volume in 1 second (% pred) pre-bronchodilator"
  */
 Profile: ForcedExpiratoryVolume_1s_PostBronchodilator
 Parent: Observation
-Id: FEV1-POST
-Title: "Forced expiratory volume in 1 second post-bronchodilator"
+Id: ForcedExpiratoryVolume1SecPostbronchodilator
+Title: "Forced Expiratory Volume In 1 Second (FEV1) Post-bronchodilator"
 Description: "Forced expiratory volume in 1 second (liters) post-bronchodilator"
 * code = $LNC#20155-8 "FEV1 --post bronchodilation"
 * value[x] only Quantity
@@ -100,8 +100,8 @@ Description: "Forced expiratory volume in 1 second (liters) post-bronchodilator"
 
 Profile: ForcedExpiratoryVolume_1s_PostBronchodilator_Zscore
 Parent: Observation
-Id: FEV1-POST-Zscore
-Title: "Forced expiratory volume in 1 second pre-bronchodilator (z-score)"
+Id: ForcedExpiratoryVolume1SecPostbronchodilator-Zscore
+Title: "Forced Expiratory Volume In 1 Second (FEV1) Post-bronchodilator Zscore"
 Description: "Forced expiratory volume in 1 second (z-score) pre-bronchodilator"
 * code
   * text = "FEV1 (z-score) post-bronchodilator"
@@ -113,8 +113,8 @@ Description: "Forced expiratory volume in 1 second (z-score) pre-bronchodilator"
 
 Profile: ForcedExpiratoryVolume_1s_PostBronchodilator_percentPredicted
 Parent: Observation
-Id: FEV1-POST-percentPredicted
-Title: "Forced expiratory volume in 1 second pre-bronchodilator (measured/predicted)"
+Id: ForcedExpiratoryVolume1SecPostbronchodilator-PercentOfPredicted
+Title: "Forced Expiratory Volume In 1 Second (FEV1) Post-bronchodilator Percent Of Predicted"
 Description: "Forced expiratory volume in 1 second (% pred) post-bronchodilator"
 * code
   * coding = $LNC#20152-5 "FEV1 measured/predicted"
@@ -126,8 +126,8 @@ Description: "Forced expiratory volume in 1 second (% pred) post-bronchodilator"
 
 Profile: ForcedExpiratoryVolume_1s_PostBronchodilator_mLChange
 Parent: Observation
-Id: FEV1-POST-mLChange
-Title: "ForcedExpiratoryVolume_1s_PostBronchodilator_mLChange"
+Id: ForcedExpiratoryVolume1SecPostbronchodilator-mLChange
+Title: "Forced Expiratory Volume In 1 Second (FEV1) Post-bronchodilator mL Change"
 Description: "Forced expiratory volume in one second, mL change from pre-bronchodilator to post-bronchodilator"
 * code
   * text = "FEV1 volume change"
@@ -139,8 +139,8 @@ Description: "Forced expiratory volume in one second, mL change from pre-broncho
 
 Profile: ForcedExpiratoryVolume_1s_PostBronchodilator_percentChange
 Parent: Observation
-Id: FEV1-POST-percentChange
-Title: "ForcedExpiratoryVolume_1s_PostBronchodilator_percentChange"
+Id: ForcedExpiratoryVolume1SecPostbronchodilator-PercentChange
+Title: "Forced Expiratory Volume In 1 Second (FEV1) Post-bronchodilator Percent Change"
 Description: "Forced expiratory volume in one second, percent change from pre-bronchodilator to post-bronchodilator"
 * code
   * text = "FEV1 percent change"

--- a/input/fsh/Profiles/spirometry/FEV1.fsh
+++ b/input/fsh/Profiles/spirometry/FEV1.fsh
@@ -4,7 +4,7 @@
 /*
  * Pre/post bronchodilator not specified
  */
-Profile: ForcedExpiratoryVolume_1s
+Profile: ForcedExpiratoryVolume1Sec
 Parent: Observation
 Id: ForcedExpiratoryVolume1Sec
 Title: "Forced Expiratory Volume In 1 Second (FEV1)"
@@ -16,7 +16,7 @@ Description: "Forced expiratory volume in 1 second"
   * system = $UCUM
   * code = #L
 
-Profile: ForcedExpiratoryVolume_1s_Zscore
+Profile: ForcedExpiratoryVolume1Sec_Zscore
 Parent: Observation
 Id: ForcedExpiratoryVolume1Sec-Zscore
 Title: "Forced Expiratory Volume In 1 Second (FEV1) Zscore"
@@ -29,7 +29,7 @@ Description: "Forced expiratory volume in 1 second (z-score)"
   * system = $UCUM
   * code = #{Zscore}
 
-Profile: ForcedExpiratoryVolume_1s_percentPredicted
+Profile: ForcedExpiratoryVolume1Sec_PercentOfPredicted
 Parent: Observation
 Id: ForcedExpiratoryVolume1Sec-PercentOfPredicted
 Title: "Forced Expiratory Volume In 1 Second (FEV1) Percent Of Predicted"
@@ -44,7 +44,7 @@ Description: "Forced expiratory volume in 1 second (% pred)"
 /*
  * Pre-bronchodilator
  */
-Profile: ForcedExpiratoryVolume_1s_PreBronchodilator
+Profile: ForcedExpiratoryVolume1SecPreBronchodilator
 Parent: Observation
 Id: ForcedExpiratoryVolume1SecPreBronchodilator
 Title: "Forced Expiratory Volume In 1 Second (FEV1) Pre-bronchodilator"
@@ -56,7 +56,7 @@ Description: "Forced expiratory volume in 1 second pre-bronchodilator"
   * system = $UCUM
   * code = #L
 
-Profile: ForcedExpiratoryVolume_1s_PreBronchodilator_Zscore
+Profile: ForcedExpiratoryVolume1SecPreBronchodilator_Zscore
 Parent: Observation
 Id: ForcedExpiratoryVolume1SecPreBronchodilator-Zscore
 Title: "Forced Expiratory Volume In 1 Second (FEV1) Pre-bronchodilator Zscore"
@@ -69,7 +69,7 @@ Description: "Forced expiratory volume in 1 second (z-score) pre-bronchodilator"
   * system = $UCUM
   * code = #{Zscore}
 
-Profile: ForcedExpiratoryVolume_1s_PreBronchodilator_percentPredicted
+Profile: ForcedExpiratoryVolume1SecPreBronchodilator_PercentOfPredicted
 Parent: Observation
 Id: ForcedExpiratoryVolume1SecPreBronchodilator-PercentOfPredicted
 Title: "Forced Expiratory Volume In 1 Second (FEV1) Pre-bronchodilator Percent Of Predicted"
@@ -86,7 +86,7 @@ Description: "Forced expiratory volume in 1 second (% pred) pre-bronchodilator"
 /*
  * Post-bronchodilator
  */
-Profile: ForcedExpiratoryVolume_1s_PostBronchodilator
+Profile: ForcedExpiratoryVolume1SecPostbronchodilator
 Parent: Observation
 Id: ForcedExpiratoryVolume1SecPostbronchodilator
 Title: "Forced Expiratory Volume In 1 Second (FEV1) Post-bronchodilator"
@@ -98,7 +98,7 @@ Description: "Forced expiratory volume in 1 second (liters) post-bronchodilator"
   * system = $UCUM
   * code = #L
 
-Profile: ForcedExpiratoryVolume_1s_PostBronchodilator_Zscore
+Profile: ForcedExpiratoryVolume1SecPostbronchodilator_Zscore
 Parent: Observation
 Id: ForcedExpiratoryVolume1SecPostbronchodilator-Zscore
 Title: "Forced Expiratory Volume In 1 Second (FEV1) Post-bronchodilator Zscore"
@@ -111,7 +111,7 @@ Description: "Forced expiratory volume in 1 second (z-score) pre-bronchodilator"
   * system = $UCUM
   * code = #{Zscore}
 
-Profile: ForcedExpiratoryVolume_1s_PostBronchodilator_percentPredicted
+Profile: ForcedExpiratoryVolume1SecPostbronchodilator_PercentOfPredicted
 Parent: Observation
 Id: ForcedExpiratoryVolume1SecPostbronchodilator-PercentOfPredicted
 Title: "Forced Expiratory Volume In 1 Second (FEV1) Post-bronchodilator Percent Of Predicted"
@@ -124,7 +124,7 @@ Description: "Forced expiratory volume in 1 second (% pred) post-bronchodilator"
   * system = $UCUM
   * code = #%
 
-Profile: ForcedExpiratoryVolume_1s_PostBronchodilator_mLChange
+Profile: ForcedExpiratoryVolume1SecPostbronchodilator_mLChange
 Parent: Observation
 Id: ForcedExpiratoryVolume1SecPostbronchodilator-mLChange
 Title: "Forced Expiratory Volume In 1 Second (FEV1) Post-bronchodilator mL Change"
@@ -137,7 +137,7 @@ Description: "Forced expiratory volume in one second, mL change from pre-broncho
   * system = $UCUM
   * code = #mL
 
-Profile: ForcedExpiratoryVolume_1s_PostBronchodilator_percentChange
+Profile: ForcedExpiratoryVolume1SecPostbronchodilator_PercentChange
 Parent: Observation
 Id: ForcedExpiratoryVolume1SecPostbronchodilator-PercentChange
 Title: "Forced Expiratory Volume In 1 Second (FEV1) Post-bronchodilator Percent Change"

--- a/input/fsh/Profiles/spirometry/FEV1_over_FVC.fsh
+++ b/input/fsh/Profiles/spirometry/FEV1_over_FVC.fsh
@@ -7,7 +7,7 @@
 Profile: FEV1_over_FVC
 Parent: Observation
 Id: FEV1-over-FVC
-Title: "FEV1_over_FVC"
+Title: "FEV1/FVC"
 Description: "FEV1/FVC"
 * code = $LNC#19926-5 "FEV1/FVC"
 * value[x] only Quantity
@@ -19,7 +19,7 @@ Description: "FEV1/FVC"
 Profile: FEV1_over_FVC_Zscore
 Parent: Observation
 Id: FEV1-over-FVC-Zscore
-Title: "FEV1_over_FVC_Zscore"
+Title: "FEV1/FVC Zscore"
 Description: "FEV1/FVC (z-score)"
 * code
   * text = "FEV1/FVC (z-score)"
@@ -35,8 +35,8 @@ Description: "FEV1/FVC (z-score)"
  */
 Profile: FEV1_over_FVC_PreBronchodilator
 Parent: Observation
-Id: FEV1-over-FVC-PRE
-Title: "FEV1_over_FVC_PRE"
+Id: FEV1-over-FVC-PreBronchodilator
+Title: "FEV1/FVC Pre-bronchodilator"
 Description: "FEV1/FVC pre-bronchodilator"
 * code
   * coding = $LNC#19926-5 "FEV1/FVC"
@@ -49,8 +49,8 @@ Description: "FEV1/FVC pre-bronchodilator"
 
 Profile: FEV1_over_FVC_PreBronchodilator_Zscore
 Parent: Observation
-Id: FEV1-over-FVC-PRE-Zscore
-Title: "FEV1_over_FVC_PRE_Zscore"
+Id: FEV1-over-FVC-PreBronchodilator-Zscore
+Title: "FEV1/FVC Pre-bronchodilator Zscore"
 Description: "FEV1/FVC (z-score) pre-bronchodilator"
 * code
   * text = "FEV1/FVC (z-score) pre-bronchodilator"
@@ -66,8 +66,8 @@ Description: "FEV1/FVC (z-score) pre-bronchodilator"
  */
 Profile: FEV1_over_FVC_PostBronchodilator
 Parent: Observation
-Id: FEV1-over-FVC-POST
-Title: "FEV1_over_FVC_POST"
+Id: FEV1-over-FVC-PostBronchodilator
+Title: "FEV1/FVC Post-bronchodilator"
 Description: "FEV1/FVC post-bronchodilator"
 * code
   * coding = $LNC#19926-5 "FEV1/FVC"
@@ -80,8 +80,8 @@ Description: "FEV1/FVC post-bronchodilator"
 
 Profile: FEV1_over_FVC_PostBronchodilator_Zscore
 Parent: Observation
-Id: FEV1-over-FVC-POST-Zscore
-Title: "FEV1_over_FVC_POST_Zscore"
+Id: FEV1-over-FVC-PostBronchodilator-Zscore
+Title: "FEV1/FVC Post-bronchodilator Zscore"
 Description: "FEV1/FVC (z-score) post-bronchodilator"
 * code
   * text = "FEV1/FVC (z-score) post-bronchodilator"

--- a/input/fsh/Profiles/spirometry/FVC.fsh
+++ b/input/fsh/Profiles/spirometry/FVC.fsh
@@ -29,7 +29,7 @@ Description: "Forced vital capacity (z-score)."
   * system = $UCUM
   * code = #{Zscore}
 
-Profile: ForcedVitalCapacity_percentPredicted
+Profile: ForcedVitalCapacity_PercentOfPredicted
 Parent: Observation
 Id: ForcedVitalCapacity-PercentOfPredicted
 Title: "Forced Vital Capacity (FVC) Percent Of Predicted"
@@ -44,7 +44,7 @@ Description: "Forced vital capacity (% pred)."
 /*
  * Pre-bronchodilator
  */
-Profile: ForcedVitalCapacity_PreBronchodilator
+Profile: ForcedVitalCapacityPreBronchodilator
 Parent: Observation
 Id: ForcedVitalCapacityPreBronchodilator
 Title: "Forced Vital Capacity (FVC) Pre-bronchodilator"
@@ -56,7 +56,7 @@ Description: "Forced vital capacity (liters) pre-bronchodilator."
   * system = $UCUM
   * code = #L
 
-Profile: ForcedVitalCapacity_PreBronchodilator_Zscore
+Profile: ForcedVitalCapacityPreBronchodilator_Zscore
 Parent: Observation
 Id: ForcedVitalCapacityPreBronchodilator-Zscore
 Title: "Forced Vital Capacity (FVC) Pre-bronchodilator Zscore"
@@ -69,7 +69,7 @@ Description: "Forced vital capacity (z-score) pre-bronchodilator."
   * system = $UCUM
   * code = #{Zscore}
 
-Profile: ForcedVitalCapacity_PreBronchodilator_percentPredicted
+Profile: ForcedVitalCapacityPreBronchodilator_PercentOfPredicted
 Parent: Observation
 Id: ForcedVitalCapacityPreBronchodilator-PercentOfPredicted
 Title: "Forced Vital Capacity (FVC) Pre-bronchodilator Percent Of Predicted"
@@ -84,7 +84,7 @@ Description: "Forced vital capacity (% pred) pre-bronchodilator."
 /*
  * Post-bronchodilator
  */
-Profile: ForcedVitalCapacity_PostBronchodilator
+Profile: ForcedVitalCapacityPostBronchodilator
 Parent: Observation
 Id: ForcedVitalCapacityPostBronchodilator
 Title: "Forced Vital Capacity (FVC) Post-bronchodilator"
@@ -96,7 +96,7 @@ Description: "Forced vital capacity post-bronchodilator"
   * system = $UCUM
   * code = #L
 
-Profile: ForcedVitalCapacity_PostBronchodilator_Zscore
+Profile: ForcedVitalCapacityPostBronchodilator_Zscore
 Parent: Observation
 Id: ForcedVitalCapacityPostBronchodilator-Zscore
 Title: "Forced Vital Capacity (FVC) Post-bronchodilator Zscore"
@@ -109,7 +109,7 @@ Description: "Forced vital capacity (z-score) post-bronchodilator."
   * system = $UCUM
   * code = #{Zscore}
 
-Profile: ForcedVitalCapacity_PostBronchodilator_percentPredicted
+Profile: ForcedVitalCapacityPostBronchodilator_PercentOfPredicted
 Parent: Observation
 Id: ForcedVitalCapacityPostBronchodilator-PercentOfPredicted
 Title: "Forced Vital Capacity (FVC) Post-bronchodilator Percent Of Predicted"
@@ -121,7 +121,7 @@ Description: "Forced vital capacity (% pred) post-bronchodilator."
   * system = $UCUM
   * code = #%
 
-Profile: ForcedVitalCapacity_PostBronchodilator_mLChange
+Profile: ForcedVitalCapacityPostBronchodilator_mLChange
 Parent: Observation
 Id: ForcedVitalCapacityPostBronchodilator-mLChange
 Title: "Forced Vital Capacity (FVC) Post-bronchodilator mL Change"
@@ -134,7 +134,7 @@ Description: "Forced vital capacity, post-bronchodilator change from pre-broncho
   * system = $UCUM
   * code = #mL
 
-Profile: ForcedVitalCapacity_PostBronchodilator_percentChange
+Profile: ForcedVitalCapacityPostBronchodilator_PercentChange
 Parent: Observation
 Id: ForcedVitalCapacityPostBronchodilator-PercentChange
 Title: "Forced Vital Capacity (FVC) Post-bronchodilator Percent Change"

--- a/input/fsh/Profiles/spirometry/FVC.fsh
+++ b/input/fsh/Profiles/spirometry/FVC.fsh
@@ -7,7 +7,7 @@
 Profile: ForcedVitalCapacity
 Parent: Observation
 Id: ForcedVitalCapacity
-Title: "Forced vital capacity"
+Title: "Forced Vital Capacity (FVC)"
 Description: "Forced vital capacity (liters)"
 * code = $LNC#19870-5 "Forced vital capacity [Volume] Respiratory system"
 * value[x] only Quantity
@@ -18,8 +18,8 @@ Description: "Forced vital capacity (liters)"
 
 Profile: ForcedVitalCapacity_Zscore
 Parent: Observation
-Id: FVC-Zscore
-Title: "Forced vital capacity z-score"
+Id: ForcedVitalCapacity-Zscore
+Title: "Forced Vital Capacity (FVC) Zscore"
 Description: "Forced vital capacity (z-score)."
 * code
   * text = "Forced vital capacity (z-score)"
@@ -31,8 +31,8 @@ Description: "Forced vital capacity (z-score)."
 
 Profile: ForcedVitalCapacity_percentPredicted
 Parent: Observation
-Id: FVC-percentPredicted
-Title: "Forced vital capacity measured/predicted"
+Id: ForcedVitalCapacity-PercentOfPredicted
+Title: "Forced Vital Capacity (FVC) Percent Of Predicted"
 Description: "Forced vital capacity (% pred)."
 * code = $LNC#19872-1 "FVC measured/predicted"
 * value[x] only Quantity
@@ -46,8 +46,8 @@ Description: "Forced vital capacity (% pred)."
  */
 Profile: ForcedVitalCapacity_PreBronchodilator
 Parent: Observation
-Id: FVC-PRE
-Title: "Forced vital capacity pre-bronchodilator"
+Id: ForcedVitalCapacityPreBronchodilator
+Title: "Forced Vital Capacity (FVC) Pre-bronchodilator"
 Description: "Forced vital capacity (liters) pre-bronchodilator."
 * code = $LNC#19876-2 "Forced vital capacity [Volume] Respiratory system by Spirometry --pre bronchodilation"
 * value[x] only Quantity
@@ -58,8 +58,8 @@ Description: "Forced vital capacity (liters) pre-bronchodilator."
 
 Profile: ForcedVitalCapacity_PreBronchodilator_Zscore
 Parent: Observation
-Id: FVC-PRE-Zscore
-Title: "Forced vital capacity pre-bronchodilator z-score"
+Id: ForcedVitalCapacityPreBronchodilator-Zscore
+Title: "Forced Vital Capacity (FVC) Pre-bronchodilator Zscore"
 Description: "Forced vital capacity (z-score) pre-bronchodilator."
 * code
   * text = "Forced vital capacity (z-score) pre-bronchodilator"
@@ -71,8 +71,8 @@ Description: "Forced vital capacity (z-score) pre-bronchodilator."
 
 Profile: ForcedVitalCapacity_PreBronchodilator_percentPredicted
 Parent: Observation
-Id: FVC-PRE-percentPredicted
-Title: "Forced vital capacity pre-bronchodilator measured/predicted"
+Id: ForcedVitalCapacityPreBronchodilator-PercentOfPredicted
+Title: "Forced Vital Capacity (FVC) Pre-bronchodilator Percent Of Predicted"
 Description: "Forced vital capacity (% pred) pre-bronchodilator."
 * code = $LNC#19871-3 "FVC pre bronchodilation measured/predicted"
 * value[x] only Quantity
@@ -86,9 +86,9 @@ Description: "Forced vital capacity (% pred) pre-bronchodilator."
  */
 Profile: ForcedVitalCapacity_PostBronchodilator
 Parent: Observation
-Id: FVC-POST
-Title: "Forced vital capacity post-bronchodilator"
-Description: "Forced vital capacity (liters) post-bronchodilator"
+Id: ForcedVitalCapacityPostBronchodilator
+Title: "Forced Vital Capacity (FVC) Post-bronchodilator"
+Description: "Forced vital capacity post-bronchodilator"
 * code =  $LNC#19874-7 "Forced vital capacity [Volume] Respiratory system by Spirometry --post bronchodilation"
 * value[x] only Quantity
 * valueQuantity
@@ -98,8 +98,8 @@ Description: "Forced vital capacity (liters) post-bronchodilator"
 
 Profile: ForcedVitalCapacity_PostBronchodilator_Zscore
 Parent: Observation
-Id: FVC-POST-Zscore
-Title: "Forced vital capacity post-bronchodilator z-score"
+Id: ForcedVitalCapacityPostBronchodilator-Zscore
+Title: "Forced Vital Capacity (FVC) Post-bronchodilator Zscore"
 Description: "Forced vital capacity (z-score) post-bronchodilator."
 * code
   * text = "Forced vital capacity (z-score) post-bronchodilator"
@@ -111,8 +111,8 @@ Description: "Forced vital capacity (z-score) post-bronchodilator."
 
 Profile: ForcedVitalCapacity_PostBronchodilator_percentPredicted
 Parent: Observation
-Id: FVC-POST-percentPredicted
-Title: "Forced vital capacity post-bronchodilator measured/predicted"
+Id: ForcedVitalCapacityPostBronchodilator-PercentOfPredicted
+Title: "Forced Vital Capacity (FVC) Post-bronchodilator Percent Of Predicted"
 Description: "Forced vital capacity (% pred) post-bronchodilator."
 * code = $LNC#19873-9 "FVC post bronchodilation measured/predicted"
 * value[x] only Quantity
@@ -123,8 +123,8 @@ Description: "Forced vital capacity (% pred) post-bronchodilator."
 
 Profile: ForcedVitalCapacity_PostBronchodilator_mLChange
 Parent: Observation
-Id: FVC-POST-mLChange
-Title: "Forced vital capacity post-bronchodilator mL change"
+Id: ForcedVitalCapacityPostBronchodilator-mLChange
+Title: "Forced Vital Capacity (FVC) Post-bronchodilator mL Change"
 Description: "Forced vital capacity, post-bronchodilator change from pre-bronchodilator (mL)"
 * code
   * text = "Forced vital capacity, post-bronchodilator change from pre-bronchodilator (mL)"
@@ -136,8 +136,8 @@ Description: "Forced vital capacity, post-bronchodilator change from pre-broncho
 
 Profile: ForcedVitalCapacity_PostBronchodilator_percentChange
 Parent: Observation
-Id: FVC-POST-percentChange
-Title: "Forced vital capacity post-bronchodilator percent change"
+Id: ForcedVitalCapacityPostBronchodilator-PercentChange
+Title: "Forced Vital Capacity (FVC) Post-bronchodilator Percent Change"
 Description: "Forced vital capacity, post-bronchodilator change from pre-bronchodilator (%)"
 * code = $LNC#69982-7 "FVC percent change Respiratory system"
 * value[x] only Quantity


### PR DESCRIPTION
As per https://github.com/Automate-Medical/fhir-pft-profile/issues/13, I've updated the profile ids and titles to conform to the naming schema we settled on.

In addition to the renamings, I also updated the description for the SpO2 profile.

I encountered two issues:

## Length of ids

### Issue

FHIR id strings cannot exceed 64 characters. This is problematic for DLCO and FEV1, both of which can have very long ids. 

For example, `DiffusionCapacityOfLungForCarbonMonoxideAtStandardBarometricPressure` is 68 characters, and `ForcedExpiratoryVolumeIn1SecondPostbronchodilator-PercentOfPredicted` is also 68 characters (no connection, same length is coincidence).

### Fix

Nearly all DLCO ids exceeded 64 characters so I replaced the substring "DIffusionCapacityOfLungForCarbonMonoxide" in each id with "DLCO".

Due to constraints on FHIR's [`id`](https://www.hl7.org/fhir/datatypes.html#id) datatype I cannot replace "Percent" with "%", so I replaced each substring "`ForcedExpiratoryVolumeIn1Second" with "ForcedExpiratoryVolume1Sec".

These changes bring minimal readability impact. The only potential future issue I forsee are if we programmatically generate ids from titles based on our naming rules.

## ids for ratios

### Issue

VI/VC and FEV1/FVC are difficult to turn into ids under our naming schema. Some examples of the style I've chosen:

_No pre/post, not a derived value:_
```yaml
Id: VI-over-VC
Title: "VI/VC"
```

```yaml
Id: FEV1-over-FVC
Title: "FEV1/FVC"
```

_Pre, not a derived value:_
```yaml
Id: FEV1-over-FVC-PreBronchodilator
Title: "FEV1/FVC Pre-bronchodilator"
```

_Pre and a derived value:_
```yaml
Id: FEV1-over-FVC-PreBronchodilator-Zscore
Title: "FEV1/FVC Pre-bronchodilator Zscore"
```

One problem I have with only using hyphens to separate the "derived" part is that an id like `VIOverVC` (or  `VIoverVC`, if we drop camelcase) is difficult to read unambiguously. This is less of a problem with `FEV1OverFVCPreBronchodilator` because the number helps indicate where the term ends and because a three-letter acronym is easier to pick out by eye.

We could change this; for example explicitly stating it's a ratio:

```yaml
Id: FEV1ToFVCRatioPreBronchodilator-Zscore
Title: "FEV1 to FVC ratio (FEV1/FVC) Pre-bronchodilator Zscore"
```

but we would still have the readability issue of `VIToVCRatio`.

### Not fixed

For now, I've left VI/VC and FEV1/FVC with hyphens. Every other profile conforms to our naming schema.