### PR TITLE
Add descriptions to profiles

### DIFF
--- a/input/fsh/Instances/FVC.fsh
+++ b/input/fsh/Instances/FVC.fsh
@@ -9,7 +9,7 @@
 Instance: FVC_PRE
 InstanceOf: ForcedVitalCapacityPreBronchodilator
 Title: "FVC (L) pre-bronchodilator"
-Description: """An example ForcedVitalCapacityPreBronchodilator resource for forced vital capacity volume, pre-bronchodilator."
+Description: "An example ForcedVitalCapacityPreBronchodilator resource for forced vital capacity volume, pre-bronchodilator."
 Usage: #example
 * text // `text` element inherited from `Observation` ancestor `DomainResource`
   * status = #additional
@@ -35,7 +35,7 @@ Usage: #example
 Instance: FVC_PRE_zScore
 InstanceOf: ForcedVitalCapacityPreBronchodilator_Zscore
 Title: "FVC z-score pre-bronchodilator"
-Description: """An example ForcedVitalCapacityPreBronchodilator_Zscore resource for forced vital capacity z-score, pre-bronchodilator."
+Description: "An example ForcedVitalCapacityPreBronchodilator_Zscore resource for forced vital capacity z-score, pre-bronchodilator."
 Usage: #example
 * id = "FVC-PRE-Zscore"
 * status = #final

--- a/input/fsh/Instances/FVC.fsh
+++ b/input/fsh/Instances/FVC.fsh
@@ -9,7 +9,7 @@
 Instance: FVC_PRE
 InstanceOf: ForcedVitalCapacityPreBronchodilator
 Title: "FVC (L) pre-bronchodilator"
-Description: "An example Observation resource for forced vital capacity volume, pre-bronchodilator."
+Description: """An example ForcedVitalCapacityPreBronchodilator resource for forced vital capacity volume, pre-bronchodilator."
 Usage: #example
 * text // `text` element inherited from `Observation` ancestor `DomainResource`
   * status = #additional
@@ -35,7 +35,7 @@ Usage: #example
 Instance: FVC_PRE_zScore
 InstanceOf: ForcedVitalCapacityPreBronchodilator_Zscore
 Title: "FVC z-score pre-bronchodilator"
-Description: "An example Observation resource for forced vital capacity z-score, pre-bronchodilator."
+Description: """An example ForcedVitalCapacityPreBronchodilator_Zscore resource for forced vital capacity z-score, pre-bronchodilator."
 Usage: #example
 * id = "FVC-PRE-Zscore"
 * status = #final
@@ -51,7 +51,7 @@ Usage: #example
 Instance: FVC_PRE_percentPredicted
 InstanceOf: ForcedVitalCapacityPreBronchodilator_PercentOfPredicted
 Title: "FVC pre-bronchodilator, % of predicted value"
-Description: "An example Observation resource for forced vital capacity measured/predicted, pre-bronchodilator."
+Description: "An example ForcedVitalCapacityPreBronchodilator_PercentOfPredicted resource for forced vital capacity measured/predicted, pre-bronchodilator."
 Usage: #example
 * id = "FVC-PRE-percentPredicted"
 * status = #final
@@ -69,7 +69,7 @@ Usage: #example
 Instance: FVC_POST
 InstanceOf: ForcedVitalCapacityPostBronchodilator
 Title: "FVC (L) post-bronchodilator"
-Description: "An example Observation resource for forced vital capacity volume, post-bronchodilator."
+Description: "An example ForcedVitalCapacityPostBronchodilator resource for forced vital capacity volume, post-bronchodilator."
 Usage: #example
 * id = "FVC-POST"
 * status = #final
@@ -86,7 +86,7 @@ Usage: #example
 Instance: FVC_POST_zScore
 InstanceOf: ForcedVitalCapacityPostBronchodilator_Zscore
 Title: "FVC z-score post-bronchodilator"
-Description: "An example Observation resource for forced vital capacity z-score, post-bronchodilator."
+Description: "An example ForcedVitalCapacityPostBronchodilator_Zscore resource for forced vital capacity z-score, post-bronchodilator."
 Usage: #example
 * id = "FVC-POST-Zscore"
 * status = #final
@@ -103,7 +103,7 @@ Usage: #example
 Instance: FVC_POST_percentPredicted
 InstanceOf: ForcedVitalCapacityPostBronchodilator_PercentOfPredicted
 Title: "FVC post-bronchodilator, % of predicted value"
-Description: "An example Observation resource for forced vital capacity measured/predicted, post-bronchodilator."
+Description: "An example ForcedVitalCapacityPostBronchodilator_PercentOfPredicted resource for forced vital capacity measured/predicted, post-bronchodilator."
 Usage: #example
 * id = "FVC-POST-percentPredicted"
 * status = #final
@@ -115,7 +115,7 @@ Usage: #example
 Instance: FVC_POST_mLChange
 InstanceOf: ForcedVitalCapacityPostBronchodilator_mLChange
 Title: "FVC post-bronchodilator, change from pre-bronchodilator (mL)"
-Description: "An example Observation resource for the volume change in forced vital capacity volume, from pre-bronchodilator to post-bronchodilator."
+Description: "An example ForcedVitalCapacityPostBronchodilator_mLChange resource for the volume change in forced vital capacity volume, from pre-bronchodilator to post-bronchodilator."
 Usage: #example
 * id = "FVC-POST-mLChange"
 * status = #final
@@ -128,7 +128,7 @@ Usage: #example
 Instance: FVC_POST_percentChange
 InstanceOf: ForcedVitalCapacityPostBronchodilator_PercentChange
 Title: "FVC post-bronchodilator, change from pre-bronchodilator (%)"
-Description: "An example Observation resource for the percent change in forced vital capacity volume, from pre-bronchodilator to post-bronchodilator."
+Description: "An example ForcedVitalCapacityPostBronchodilator_PercentChange resource for the percent change in forced vital capacity volume, from pre-bronchodilator to post-bronchodilator."
 Usage: #example
 * id = "FVC-post-percentChange"
 * status = #final

--- a/input/fsh/Instances/PFT_DiagnosticReport.fsh
+++ b/input/fsh/Instances/PFT_DiagnosticReport.fsh
@@ -4,7 +4,7 @@
 Instance: PFT_DiagnosticReport
 InstanceOf: PulmonaryFunctionTestDiagnosticReport
 Title: "PFT DiagnosticReport"
-Description: "An example of how a DiagnosticReport for a PFT may be constructed."
+Description: "An example PulmonaryFunctionTestDiagnosticReport resource demonstrating how a DiagnosticReport for a PFT may be constructed."
 Usage: #example
 * id = "diagnostic-report"
 * status = #final

--- a/input/fsh/Instances/SPO2_RESTING.fsh
+++ b/input/fsh/Instances/SPO2_RESTING.fsh
@@ -3,6 +3,7 @@
 Instance: SPO2_RESTING
 InstanceOf: SPO2AtRest
 Title: "SpO2 at rest"
+Description: """An example SPO2AtRest resource for oxygen saturation by pulse oximetry at rest."""
 Usage: #inline
 * id = "SPO2-RESTING"
 * status = #final

--- a/input/fsh/Profiles/SPO2_RESTING.fsh
+++ b/input/fsh/Profiles/SPO2_RESTING.fsh
@@ -2,7 +2,11 @@ Profile: SPO2AtRest
 Parent: Observation
 Id: SPO2AtRest
 Title: "SpO2 at rest"
-Description: "A measurement of oxygen saturation in arterial blood taken by pulse oximetry, with the patient at rest."
+Description: """A measurement of oxygen saturation taken by pulse oximetry (SpO2), with the patient at rest.
+
+Pulse oximetry is a non-invasive procedure for measuring the percent of hemoglobin in the blood that is saturated with oxygen.
+
+While oxygen saturation is not part of a specific panel of pulmonary function tests, it nonetheless has clinical value and may be included in diagnostic reports."""
 * code = $LNC#59417-6 "Oxygen saturation in Arterial blood by Pulse oximetry --resting"
 * valueQuantity
   * unit = "%"

--- a/input/fsh/Profiles/diffusing-capacity/AlveolarVolume.fsh
+++ b/input/fsh/Profiles/diffusing-capacity/AlveolarVolume.fsh
@@ -5,7 +5,8 @@ Profile: AlveolarVolume
 Parent: Observation
 Id: AlveolarVolume
 Title: "Alveolar Volume (VA)"
-Description: "A measurement of alveolar volume, in liters."
+// TODO: Expand description to explain how alveolar volume is measured or calculated.
+Description: """A measurement of alveolar volume (VA)."""
 * code = $SCT#251953007 "Alveolar volume (observable entity)"
 * value[x] only Quantity
 * valueQuantity
@@ -17,7 +18,10 @@ Profile: AlveolarVolume_Zscore
 Parent: Observation
 Id: AlveolarVolume-Zscore
 Title: "Alveolar Volume (VA) Zscore"
-Description: "The z-score of an alveolar volume measurement, calculated from some reference distribution."
+// TODO: Expand description to explain how alveolar volume is measured or calculated.
+Description: """The z-score of an alveolar volume (VA) measurement.
+
+The Zscore of a measured value is determined by comparing the measured value to some reference distribution based on the patient's demographic information. The Zscore is useful as an indicator of how abnormal the measured value is."""
 * code
   * text = "Alveolar volume (z-score)"
 * value[x] only Quantity
@@ -30,7 +34,10 @@ Profile: AlveolarVolume_PercentOfPredicted
 Parent: Observation
 Id: AlveolarVolume-PercentOfPredicted
 Title: "Alveolar Volume (VA) Percent Of Predicted"
-Description: "An alveolar volume measurement as the percentage of some predicted reference value."
+// TODO: Expand description to explain how alveolar volume is measured or calculated.
+Description: """The ratio of a forced vital capacity (FVC) measurement to some predicted value, expressed as the percentage `measured/predicted`. This is also referred to as \"% predicted\" or \"% pred\".
+
+The predicted value (also referred to as the \"reference value\") is determined by the patient's demographic information. The ratio of the measured value to the predicted value is useful as an indicator of how abnormal the measured value is. """
 * code
   * text = "Alveolar volume measured/predicted"
 * value[x] only Quantity

--- a/input/fsh/Profiles/diffusing-capacity/DLCO.fsh
+++ b/input/fsh/Profiles/diffusing-capacity/DLCO.fsh
@@ -11,7 +11,9 @@ Title: "Diffusion Capacity Of Lung For Carbon Monoxide (DLCO)"
 // TODO: Expand description to explain why carbon monoxide is used, why the unit is mL/min/mmHg, etc.
 Description: """A measurement of diffusion capacity of the lung for carbon monoxide (DLCO). Also referred to as transfer capacity of the lung for carbon monoxide (TLCO).
 
-DLCO is a test of the lungs' ability to transfer inhaled gas to the bloodstream."""
+DLCO is a test of the lungs' ability to transfer inhaled gas to the bloodstream, measured in milliliters of carbon monoxide per minute per millimeter of mercury (mL/min/mmHg). Carbon monoxide (CO), measured in milliliters, is used because it follows a similar pathway as oxygen and has a high binding affinity for hemoglobin in the blood. Barometric pressure, measured in milliters of mercury, affects the absorption of gasses from the lungs and hence is relevant to the measurement of DLCO.
+
+This profile is for a DLCO observation which is not specified as adjusted for barometric pressure."""
 * code = $LNC#19911-7 "Diffusion capacity.carbon monoxide"
 * value[x] only Quantity
 * valueQuantity
@@ -27,7 +29,11 @@ Profile: DLCOAtStandardBarometricPressure
 Parent: Observation
 Id: DLCOAtStandardBarometricPressure
 Title: "Diffusion Capacity Of Lung For Carbon Monoxide (DLCO) At Standard Barometric Pressure (PB)"
-Description: "Diffusion capacity of lung for carbon monoxide at standard barometric pressure."
+Description: """A measurement of diffusion capacity of the lung for carbon monoxide (DLCO) performed at standard barometric pressure. Also referred to as transfer capacity of the lung for carbon monoxide (TLCO).
+
+DLCO is a test of the lungs' ability to transfer inhaled gas to the bloodstream, measured in milliliters of carbon monoxide per minute per millimeter of mercury (mL/min/mmHg). Carbon monoxide (CO), measured in milliliters, is used because it follows a similar pathway as oxygen and has a high binding affinity for hemoglobin in the blood. Barometric pressure, measured in milliters of mercury, affects the absorption of gasses from the lungs and hence is relevant to the measurement of DLCO.
+
+This profile is for a DLCO observation which was performed at standard barometric pressure."""
 * code
   * text = "Diffusion capacity of lung for carbon monoxide at standard barometric pressure"
 * value[x] only Quantity
@@ -40,7 +46,13 @@ Profile: DLCOAtStandardBarometricPressure_Zscore
 Parent: Observation
 Id: DLCOAtStandardBarometricPressure-Zscore
 Title: "Diffusion Capacity Of Lung For Carbon Monoxide (DLCO) At Standard Barometric Pressure (PB) Zscore"
-Description: "Diffusion capacity of lung for carbon monoxide at standard barometric pressure (z-score)."
+Description: """The Zscore of a diffusion capacity of the lung for carbon monoxide (DLCO) measurement performed at standard barometric pressure. Also referred to as transfer capacity of the lung for carbon monoxide (TLCO).
+
+DLCO is a test of the lungs' ability to transfer inhaled gas to the bloodstream, measured in milliliters of carbon monoxide per minute per millimeter of mercury (mL/min/mmHg). Carbon monoxide (CO), measured in milliliters, is used because it follows a similar pathway as oxygen and has a high binding affinity for hemoglobin in the blood. Barometric pressure, measured in milliters of mercury, affects the absorption of gasses from the lungs and hence is relevant to the measurement of DLCO.
+
+The Zscore of a measured value is determined by comparing the measured value to some reference distribution based on the patient's demographic information. The Zscore is useful as an indicator of how abnormal the measured value is.
+
+This profile is for the Zscore of a DLCO observation which was performed at standard barometric pressure."""
 * code
   * text = "Diffusion capacity of lung for carbon monoxide at standard barometric pressure (z-score)"
 * value[x] only Quantity
@@ -53,7 +65,13 @@ Profile: DLCOAtStandardBarometricPressure_PercentOfPredicted
 Parent: Observation
 Id: DLCOAtStandardBarometricPressure-PercentOfPredicted
 Title: "Diffusion Capacity Of Lung For Carbon Monoxide (DLCO) At Standard Barometric Pressure (PB) Percent Of Predicted"
-Description: "Diffusion capacity of lung for carbon monoxide at standard barometric pressure (% of predicted)."
+Description: """The ratio of a diffusion capacity of the lung for carbon monoxide (DLCO) measurement performed at standard barometric pressure to some predicted value, expressed as the percentage `measured/predicted`. Also referred to as transfer capacity of the lung for carbon monoxide (TLCO).
+
+DLCO is a test of the lungs' ability to transfer inhaled gas to the bloodstream, measured in milliliters of carbon monoxide per minute per millimeter of mercury (mL/min/mmHg). Carbon monoxide (CO), measured in milliliters, is used because it follows a similar pathway as oxygen and has a high binding affinity for hemoglobin in the blood. Barometric pressure, measured in milliters of mercury, affects the absorption of gasses from the lungs and hence is relevant to the measurement of DLCO.
+
+The predicted value (also referred to as the \"reference value\") is determined by the patient's demographic information. The ratio of the measured value to the predicted value is useful as an indicator of how abnormal the measured value is.
+
+This profile is for the measured/predicted ratio of a DLCO observation which was performed at standard barometric pressure."""
 * code
   * text = "Diffusion capacity of lung for carbon monoxide at standard barometric pressure (% of predicted)"
 * value[x] only Quantity
@@ -69,7 +87,10 @@ Profile: DLCOAdjustedForHemoglobin
 Parent: Observation
 Id: DLCOAdjustedForHemoglobin
 Title: "Diffusion Capacity Of Lung For Carbon Monoxide (DLCO) Adjusted For Hemoglobin (Hb)"
-Description: "Diffusion capacity of lung for carbon monoxide, adjusted for hemoglobin."
+// TODO: see issue #21 <https://github.com/Automate-Medical/pft-ig/issues/21>
+Description: """A measurement of diffusion capacity of the lung for carbon monoxide (DLCO) adjusted for hemoglobin. Also referred to as transfer capacity of the lung for carbon monoxide (TLCO).
+
+DLCO is a test of the lungs' ability to transfer inhaled gas to the bloodstream, measured in milliliters of carbon monoxide per minute per millimeter of mercury (mL/min/mmHg). Carbon monoxide (CO), measured in milliliters, is used because it follows a similar pathway as oxygen and has a high binding affinity for hemoglobin in the blood. Barometric pressure, measured in milliters of mercury, affects the absorption of gasses from the lungs and hence is relevant to the measurement of DLCO."""
 * code = $LNC#19913-3 "Diffusion capacity.carbon monoxide adjusted for hemoglobin"
 * value[x] only Quantity
 * valueQuantity
@@ -81,6 +102,7 @@ Profile: DLCOAdjustedForHemoglobin_PercentOfPredicted
 Parent: Observation
 Id: DLCOAdjustedForHemoglobin-PercentOfPredicted
 Title: "Diffusion Capacity Of Lung For Carbon Monoxide (DLCO) Adjusted For Hemoglobin (Hb) Percent Of Predicted"
+// TODO: see issue #21 <https://github.com/Automate-Medical/pft-ig/issues/21>
 Description: "Diffusion capacity of lung for carbon monoxide, adjusted for hemoglobin (% of predicted)."
 * code
   * text = "Diffusion capacity.carbon monoxide adjusted for hemoglobin measured/predicted"

--- a/input/fsh/Profiles/diffusing-capacity/DLCO.fsh
+++ b/input/fsh/Profiles/diffusing-capacity/DLCO.fsh
@@ -8,7 +8,10 @@ Profile: DLCO
 Parent: Observation
 Id: DLCO
 Title: "Diffusion Capacity Of Lung For Carbon Monoxide (DLCO)"
-Description: "Diffusion capacity of lung for carbon monoxide."
+// TODO: Expand description to explain why carbon monoxide is used, why the unit is mL/min/mmHg, etc.
+Description: """A measurement of diffusion capacity of the lung for carbon monoxide (DLCO). Also referred to as transfer capacity of the lung for carbon monoxide (TLCO).
+
+DLCO is a test of the lungs' ability to transfer inhaled gas to the bloodstream."""
 * code = $LNC#19911-7 "Diffusion capacity.carbon monoxide"
 * value[x] only Quantity
 * valueQuantity

--- a/input/fsh/Profiles/diffusing-capacity/KCO.fsh
+++ b/input/fsh/Profiles/diffusing-capacity/KCO.fsh
@@ -14,9 +14,9 @@ Also referred to as KCO or DLCO/VA."""
 * code = $LNC#19916-6	"Diffusion capacity/Alveolar volume	"
 * value[x] only Quantity
 * valueQuantity
-  * unit = "mL/min/mmHg"
+  * unit = "mL/min/mmHg/L"
   * system = $UCUM
-  * code = #mL/min/mmHg
+  * code = #mL/min/mmHg/L
 
 Profile: KCO_Zscore
 Parent: Observation
@@ -58,9 +58,9 @@ Also referred to as KCO or DLCO/VA."""
 * code = $LNC#82619-8	"Diffusion capacity/Alveolar volume --pre bronchodilation"
 * value[x] only Quantity
 * valueQuantity
-  * unit = "mL/min/mmHg"
+  * unit = "mL/min/mmHg/L"
   * system = $UCUM
-  * code = #mL/min/mmHg
+  * code = #mL/min/mmHg/L
 
 Profile: KCOPreBronchodilator_Zscore
 Parent: Observation
@@ -99,9 +99,9 @@ Description: "Carbon monoxide transfer coefficient, post-bronchodilator. Note: a
 * code = $LNC#82620-6	"Diffusion capacity/Alveolar volume --post bronchodilation"
 * value[x] only Quantity
 * valueQuantity
-  * unit = "mL/min/mmHg"
+  * unit = "mL/min/mmHg/L"
   * system = $UCUM
-  * code = #mL/min/mmHg
+  * code = #mL/min/mmHg/L
 
 
 Profile: KCOPostBronchodilator_Zscore

--- a/input/fsh/Profiles/diffusing-capacity/KCO.fsh
+++ b/input/fsh/Profiles/diffusing-capacity/KCO.fsh
@@ -8,9 +8,7 @@ Profile: KCO
 Parent: Observation
 Id: KCO
 Title: "KCO"
-Description: """A measurement of a carbon monoxide transfer coefficient, in mL/min/mmHg.
-
-Also referred to as KCO or DLCO/VA."""
+Description: """A measurement of carbon monoxide transfer coefficient (KCO). KCO is also referred to as DLCO/VA."""
 * code = $LNC#19916-6	"Diffusion capacity/Alveolar volume	"
 * value[x] only Quantity
 * valueQuantity
@@ -22,7 +20,7 @@ Profile: KCO_Zscore
 Parent: Observation
 Id: KCO-Zscore
 Title: "KCO Zscore"
-Description: "The z-score of a carbon monoxide transfer coefficient measurement, calculated from some reference distribution."
+Description: """The Zscore of a carbon monoxide transfer coefficient (KCO) measurement. KCO is also referred to as DLCO/VA."""
 * code
   * text = "Diffusion capacity/Alveolar volume (z-score)"
 * value[x] only Quantity
@@ -35,7 +33,7 @@ Profile: KCO_PercentOfPredicted
 Parent: Observation
 Id: KCO-PercentOfPredicted
 Title: "KCO Percent Of Predicted"
-Description: "A measurement of carbon monoxide transfer coefficient as the percentage of some predicted reference value."
+Description: """The ratio of a carbon monoxide transfer coefficient (KCO) measurement to some predicted value, expressed as the percentage `measured/predicted`. This is also referred to as \"% predicted\" or \"% pred\"."""
 * code
   * text = "Diffusion capacity/Alveolar volume (measured/predicted)"
 * value[x] only Quantity
@@ -52,9 +50,7 @@ Profile: KCOPreBronchodilator
 Parent: Observation
 Id: KCOPreBronchodilator
 Title: "KCO Pre-bronchodilator"
-Description: """A measurement of carbon monoxide transfer coefficient pre-bronchodilation, in mL/min/mmHg.
-
-Also referred to as KCO or DLCO/VA."""
+Description: """A measurement of carbon monoxide transfer coefficient (KCO) performed pre-bronchodilator. KCO is also referred to as DLCO/VA."""
 * code = $LNC#82619-8	"Diffusion capacity/Alveolar volume --pre bronchodilation"
 * value[x] only Quantity
 * valueQuantity
@@ -66,7 +62,7 @@ Profile: KCOPreBronchodilator_Zscore
 Parent: Observation
 Id: KCOPreBronchodilator-Zscore
 Title: "KCO Pre-bronchodilator Zscore"
-Description: "Carbon monoxide transfer coefficient pre-bronchodilator z-score. Note: also known as KCO or DLCO/VA."
+Description: """The Zscore of a carbon monoxide transfer coefficient (KCO) measurement performed pre-bronchodilator. KCO is also referred to as DLCO/VA"""
 * code
   * text = "Diffusion capacity/Alveolar volume (z-score) pre-bronchodilator"
 * value[x] only Quantity
@@ -79,7 +75,7 @@ Profile: KCOPreBronchodilator_PercentOfPredicted
 Parent: Observation
 Id: KCOPreBronchodilator-PercentOfPredicted
 Title: "KCO Pre-bronchodilator Percent Of Predicted"
-Description: "Carbon monoxide transfer coefficient (% predicted), pre-bronchodilator. Note: also known as KCO or DLCO/VA."
+Description: """The ratio of a carbon monoxide transfer coefficient (KCO) measurement performed pre-bronchodilator to some predicted value, expressed as the percentage `measured/predicted`. This is also referred to as \"% predicted\" or \"% pred\"."""
 * code
   * text = "Diffusion capacity/Alveolar volume (measured/predicted) pre-bronchodilator"
 * value[x] only Quantity
@@ -95,7 +91,7 @@ Profile: KCOPostBronchodilator
 Parent: Observation
 Id: KCOPostBronchodilator
 Title: "KCO Post-bronchodilator"
-Description: "Carbon monoxide transfer coefficient, post-bronchodilator. Note: also known as KCO or DLCO/VA."
+Description: """A measurement of carbon monoxide transfer coefficient (KCO) performed post-bronchodilator. KCO is also referred to as DLCO/VA."""
 * code = $LNC#82620-6	"Diffusion capacity/Alveolar volume --post bronchodilation"
 * value[x] only Quantity
 * valueQuantity
@@ -108,7 +104,7 @@ Profile: KCOPostBronchodilator_Zscore
 Parent: Observation
 Id: KCOPostBronchodilator-Zscore
 Title: "KCO Post-bronchodilator Zscore"
-Description: "Carbon monoxide transfer coefficient post-bronchodilator z-score. Note: also known as KCO or DLCO/VA."
+Description: """The Zscore of a carbon monoxide transfer coefficient (KCO) measurement performed post-bronchodilator. KCO is also referred to as DLCO/VA"""
 * code
   * text = "Diffusion capacity/Alveolar volume (z-score) post-bronchodilator"
 * value[x] only Quantity
@@ -121,7 +117,7 @@ Profile: KCOPostBronchodilator_PercentOfPredicted
 Parent: Observation
 Id: KCOPostBronchodilator-PercentOfPredicted
 Title: "KCO Post-bronchodilator Percent Of Predicted"
-Description: "Carbon monoxide transfer coefficient (% predicted), post-bronchodilator. Note: also known as KCO or DLCO/VA."
+Description: """The ratio of a carbon monoxide transfer coefficient (KCO) measurement performed post-bronchodilator to some predicted value, expressed as the percentage `measured/predicted`. This is also referred to as \"% predicted\" or \"% pred\"."""
 * code
   * text = "Diffusion capacity/Alveolar volume (measured/predicted) pre-bronchodilator"
 * value[x] only Quantity

--- a/input/fsh/Profiles/diffusing-capacity/TotalLungCapacityByHeliumSingleBreath.fsh
+++ b/input/fsh/Profiles/diffusing-capacity/TotalLungCapacityByHeliumSingleBreath.fsh
@@ -3,7 +3,10 @@ Profile: TotalLungCapacityByHeliumSingleBreath
 Parent: Observation
 Id: TotalLungCapacityByHeliumSingleBreath
 Title: "Total Lung Capacity By Helium Single Breath (TLC_sb)"
-Description: "A measurement of total lung capacity by helium, single breath, in liters."
+// TODO: Expand description to explain how this is measured or calculated.
+Description: """A measurement of total lung capacity by helium single breath (TLC_sb).
+
+Total lung capacity by helium single breath is the maximum volume of air, in liters, that the lungs can contain."""
 * code = $LNC#19858-0 "Total lung capacity by Helium single breath"
 * value[x] only Quantity
 * valueQuantity

--- a/input/fsh/Profiles/diffusing-capacity/VI_over_VC.fsh
+++ b/input/fsh/Profiles/diffusing-capacity/VI_over_VC.fsh
@@ -1,9 +1,19 @@
-/* Profile for VI/VC Observation. */
+/*
+ * Profile for VI/VC (ratio of inspired volume to vital capacity) Observation.
+ *
+ * NOTE: Vital capacity is usually written as "VC" or "V_C" where the C is subscripted.
+ * I've seen some occurrences of pulmonary capillary blood volume also written as "V_C".
+ * For example, see table 16 of "Interpretative Strategies for Lung Function Tests" (2005),
+ * available at: <https://pubmed.ncbi.nlm.nih.gov/16264058/>
+ *
+ * This is very confusing!
+ */
 Profile: VI_over_VC
 Parent: Observation
 Id: VI-over-VC
 Title: "VI/VC"
-Description: "Inspired volume (V_I) as a percentage of vital capacity (V_C)."
+// TODO: Expand description to explain what VI and VC are, and how they are measured or calculated.
+Description: """The ratio of inspired volume (VI) to vital capacity (VC), expressed as the percentage `VI/VC`."""
 * code
   * text = "VI/VC"
 * value[x] only Quantity

--- a/input/fsh/Profiles/spirometry/FET.fsh
+++ b/input/fsh/Profiles/spirometry/FET.fsh
@@ -8,7 +8,11 @@ Profile: ForcedExpiratoryTime
 Parent: Observation
 Id: ForcedExpiratoryTime
 Title: "Forced Expiratory Time (FET)"
-Description: "Forced expiratory time (seconds)"
+Description: """A measurement of forced expiratory time (FET).
+
+Forced expiratory time is the total length of time, in seconds, that it takes to forcibly exhale fully after taking as deep a breath as possible.
+
+This profile is for a forced expiratory time observation which was not specified as performed pre or post-bronchodilator. Measurements of forced expiratory time (and spirometry tests in general) may be performed both before and after administering a bronchodilator to the patient, in order to study the bronchodilator's effectiveness for treating their respiratory conditions."""
 * code = $LNC#65819-5 "Forced expiratory time"
 * value[x] only Quantity
 * valueQuantity
@@ -24,7 +28,11 @@ Profile: ForcedExpiratoryTimePreBronchodilator
 Parent: Observation
 Id: ForcedExpiratoryTime-PreBronchodilator
 Title: "Forced Expiratory Time (FET) Pre-bronchodilator"
-Description: "Forced expiratory time (seconds) pre-bronchodilator"
+Description: """A measurement of forced expiratory time (FET) performed pre-bronchodilator.
+
+Forced expiratory time is the total length of time, in seconds, that it takes to forcibly exhale fully after taking as deep a breath as possible.
+
+This profile is for a forced expiratory time observation which was performed pre-bronchodilator. Measurements of forced expiratory time (and spirometry tests in general) may be performed both before and after administering a bronchodilator to the patient, in order to study the bronchodilator's effectiveness for treating their respiratory conditions."""
 * code
   * coding = $LNC#65819-5 "Forced expiratory time"
   * text = "Forced expiratory time pre-bronchodilator"
@@ -41,7 +49,11 @@ Profile: ForcedExpiratoryTimePostBronchodilator
 Parent: Observation
 Id: ForcedExpiratoryTime-PostBronchodilator
 Title: "Forced Expiratory Time (FET) Post-bronchodilator"
-Description: "Forced expiratory time (seconds) post-bronchodilator"
+Description: """A measurement of forced expiratory time (FET) performed post-bronchodilator.
+
+Forced expiratory time is the total length of time, in seconds, that it takes to forcibly exhale fully after taking as deep a breath as possible.
+
+This profile is for a forced expiratory time observation which was performed post-bronchodilator. Measurements of forced expiratory time (and spirometry tests in general) may be performed both before and after administering a bronchodilator to the patient, in order to study the bronchodilator's effectiveness for treating their respiratory conditions."""
 * code
   * coding = $LNC#65819-5 "Forced expiratory time"
   * text = "Forced expiratory time post-bronchodilator"

--- a/input/fsh/Profiles/spirometry/FEV1.fsh
+++ b/input/fsh/Profiles/spirometry/FEV1.fsh
@@ -8,7 +8,11 @@ Profile: ForcedExpiratoryVolume1Sec
 Parent: Observation
 Id: ForcedExpiratoryVolume1Sec
 Title: "Forced Expiratory Volume In 1 Second (FEV1)"
-Description: "Forced expiratory volume in 1 second"
+Description: """A measurement of forced expiratory volume in one second (FEV1).
+
+Forced expiratory volume in one second is the total volume of air, in liters, that can be forcibly exhaled in one second.
+
+This profile is for a forced expiratory volume in one second observation which was not specified as performed pre or post-bronchodilator. Measurements of forced expiratory volume (and spirometry tests in general) may be performed both before and after administering a bronchodilator to the patient, in order to study the bronchodilator's effectiveness for treating their respiratory conditions."""
 * code = $LNC#20150-9 "FEV1"
 * value[x] only Quantity
 * valueQuantity
@@ -20,7 +24,13 @@ Profile: ForcedExpiratoryVolume1Sec_Zscore
 Parent: Observation
 Id: ForcedExpiratoryVolume1Sec-Zscore
 Title: "Forced Expiratory Volume In 1 Second (FEV1) Zscore"
-Description: "Forced expiratory volume in 1 second (z-score)"
+Description: """The Zscore of a forced expiratory volume in one second (FEV1) measurement.
+
+Forced expiratory volume in one second is the total volume of air, in liters, that can be forcibly exhaled in one second.
+
+The Zscore of a measured value is determined by comparing the measured value to some reference distribution based on the patient's demographic information. The Zscore is useful as an indicator of how abnormal the measured value is.
+
+This profile is for the Zscore of a forced expiratory volume in one second observation which was not specified as performed pre or post-bronchodilator. Measurements of forced expiratory volume (and spirometry tests in general) may be performed both before and after administering a bronchodilator to the patient, in order to study the bronchodilator's effectiveness for treating their respiratory conditions."""
 * code
   * text = "FEV1 (z-score)"
 * value[x] only Quantity
@@ -33,7 +43,13 @@ Profile: ForcedExpiratoryVolume1Sec_PercentOfPredicted
 Parent: Observation
 Id: ForcedExpiratoryVolume1Sec-PercentOfPredicted
 Title: "Forced Expiratory Volume In 1 Second (FEV1) Percent Of Predicted"
-Description: "Forced expiratory volume in 1 second (% pred)"
+Description: """The ratio of a forced expiratory volume in one second (FEV1) measurement to some predicted value, expressed as the percentage `measured/predicted`. This is also referred to as \"% predicted\" or \"% pred\".
+
+Forced expiratory volume in one second is the total volume of air, in liters, that can be forcibly exhaled in one second.
+
+The predicted value (also referred to as the \"reference value\") is determined by the patient's demographic information. The ratio of the measured value to the predicted value is useful as an indicator of how abnormal the measured value is.
+
+This profile is for the measured/predicted ratio of a forced expiratory volume in one second observation which was not specified as performed pre or post-bronchodilator. Measurements of forced expiratory volume (and spirometry tests in general) may be performed both before and after administering a bronchodilator to the patient, in order to study the bronchodilator's effectiveness for treating their respiratory conditions."""
 * code = $LNC#20152-5 "FEV1 measured/predicted"
 * value[x] only Quantity
   * unit = "%"
@@ -48,7 +64,11 @@ Profile: ForcedExpiratoryVolume1SecPreBronchodilator
 Parent: Observation
 Id: ForcedExpiratoryVolume1SecPreBronchodilator
 Title: "Forced Expiratory Volume In 1 Second (FEV1) Pre-bronchodilator"
-Description: "Forced expiratory volume in 1 second pre-bronchodilator"
+Description: """A measurement of forced expiratory volume in one second (FEV1) performed pre-bronchodilator.
+
+Forced expiratory volume in one second is the total volume of air, in liters, that can be forcibly exhaled in one second.
+
+This profile is for a forced expiratory volume in one second observation which was performed pre-bronchodilator. Measurements of forced expiratory volume (and spirometry tests in general) may be performed both before and after administering a bronchodilator to the patient, in order to study the bronchodilator's effectiveness for treating their respiratory conditions."""
 * code = $LNC#20157-4 "FEV1 --pre bronchodilation"
 * value[x] only Quantity
 * valueQuantity
@@ -60,7 +80,13 @@ Profile: ForcedExpiratoryVolume1SecPreBronchodilator_Zscore
 Parent: Observation
 Id: ForcedExpiratoryVolume1SecPreBronchodilator-Zscore
 Title: "Forced Expiratory Volume In 1 Second (FEV1) Pre-bronchodilator Zscore"
-Description: "Forced expiratory volume in 1 second (z-score) pre-bronchodilator"
+Description: """The Zscore of a forced expiratory volume in one second (FEV1) measurement performed pre-bronchodilator..
+
+Forced expiratory volume in one second is the total volume of air, in liters, that can be forcibly exhaled in one second.
+
+The Zscore of a measured value is determined by comparing the measured value to some reference distribution based on the patient's demographic information. The Zscore is useful as an indicator of how abnormal the measured value is.
+
+This profile is for the Zscore of a forced expiratory volume in one second observation which was performed pre-bronchodilator. Measurements of forced expiratory volume (and spirometry tests in general) may be performed both before and after administering a bronchodilator to the patient, in order to study the bronchodilator's effectiveness for treating their respiratory conditions."""
 * code
   * text = "FEV1 (z-score) pre-bronchodilator"
 * value[x] only Quantity
@@ -73,7 +99,13 @@ Profile: ForcedExpiratoryVolume1SecPreBronchodilator_PercentOfPredicted
 Parent: Observation
 Id: ForcedExpiratoryVolume1SecPreBronchodilator-PercentOfPredicted
 Title: "Forced Expiratory Volume In 1 Second (FEV1) Pre-bronchodilator Percent Of Predicted"
-Description: "Forced expiratory volume in 1 second (% pred) pre-bronchodilator"
+Description: """The ratio of a forced expiratory volume in one second (FEV1) measurement performed pre-bronchodilator to some predicted value, expressed as the percentage `measured/predicted`. This is also referred to as \"% predicted\" or \"% pred\".
+
+Forced expiratory volume in one second is the total volume of air, in liters, that can be forcibly exhaled in one second.
+
+The predicted value (also referred to as the \"reference value\") is determined by the patient's demographic information. The ratio of the measured value to the predicted value is useful as an indicator of how abnormal the measured value is.
+
+This profile is for the measured/predicted ratio of a forced expiratory volume in one second observation which was performed pre-bronchodilator. Measurements of forced expiratory volume (and spirometry tests in general) may be performed both before and after administering a bronchodilator to the patient, in order to study the bronchodilator's effectiveness for treating their respiratory conditions."""
 * code
   * coding = $LNC#20152-5 "FEV1 measured/predicted"
   * text = "FEV1 measured/predicted pre-bronchodilator"
@@ -90,7 +122,11 @@ Profile: ForcedExpiratoryVolume1SecPostbronchodilator
 Parent: Observation
 Id: ForcedExpiratoryVolume1SecPostbronchodilator
 Title: "Forced Expiratory Volume In 1 Second (FEV1) Post-bronchodilator"
-Description: "Forced expiratory volume in 1 second (liters) post-bronchodilator"
+Description: """A measurement of forced expiratory volume in one second (FEV1) performed post-bronchodilator.
+
+Forced expiratory volume in one second is the total volume of air, in liters, that can be forcibly exhaled in one second.
+
+This profile is for a forced expiratory volume in one second observation which was performed post-bronchodilator. Measurements of forced expiratory volume (and spirometry tests in general) may be performed both before and after administering a bronchodilator to the patient, in order to study the bronchodilator's effectiveness for treating their respiratory conditions."""
 * code = $LNC#20155-8 "FEV1 --post bronchodilation"
 * value[x] only Quantity
 * valueQuantity
@@ -102,7 +138,13 @@ Profile: ForcedExpiratoryVolume1SecPostbronchodilator_Zscore
 Parent: Observation
 Id: ForcedExpiratoryVolume1SecPostbronchodilator-Zscore
 Title: "Forced Expiratory Volume In 1 Second (FEV1) Post-bronchodilator Zscore"
-Description: "Forced expiratory volume in 1 second (z-score) post-bronchodilator"
+Description:  """The Zscore of a forced expiratory volume in one second (FEV1) measurement performed post-bronchodilator..
+
+Forced expiratory volume in one second is the total volume of air, in liters, that can be forcibly exhaled in one second.
+
+The Zscore of a measured value is determined by comparing the measured value to some reference distribution based on the patient's demographic information. The Zscore is useful as an indicator of how abnormal the measured value is.
+
+This profile is for the Zscore of a forced expiratory volume in one second observation which was performed post-bronchodilator. Measurements of forced expiratory volume (and spirometry tests in general) may be performed both before and after administering a bronchodilator to the patient, in order to study the bronchodilator's effectiveness for treating their respiratory conditions."""
 * code
   * text = "FEV1 (z-score) post-bronchodilator"
 * value[x] only Quantity
@@ -115,7 +157,13 @@ Profile: ForcedExpiratoryVolume1SecPostbronchodilator_PercentOfPredicted
 Parent: Observation
 Id: ForcedExpiratoryVolume1SecPostbronchodilator-PercentOfPredicted
 Title: "Forced Expiratory Volume In 1 Second (FEV1) Post-bronchodilator Percent Of Predicted"
-Description: "Forced expiratory volume in 1 second (% pred) post-bronchodilator"
+Description: """The ratio of a forced expiratory volume in one second (FEV1) measurement performed post-bronchodilator to some predicted value, expressed as the percentage `measured/predicted`. This is also referred to as \"% predicted\" or \"% pred\".
+
+Forced expiratory volume in one second is the total volume of air, in liters, that can be forcibly exhaled in one second.
+
+The predicted value (also referred to as the \"reference value\") is determined by the patient's demographic information. The ratio of the measured value to the predicted value is useful as an indicator of how abnormal the measured value is.
+
+This profile is for the measured/predicted ratio of a forced expiratory volume in one second observation which was performed post-bronchodilator. Measurements of forced expiratory volume (and spirometry tests in general) may be performed both before and after administering a bronchodilator to the patient, in order to study the bronchodilator's effectiveness for treating their respiratory conditions."""
 * code
   * coding = $LNC#20152-5 "FEV1 measured/predicted"
   * text = "FEV1 measured/predicted post-bronchodilator"
@@ -128,7 +176,12 @@ Profile: ForcedExpiratoryVolume1SecPostbronchodilator_mLChange
 Parent: Observation
 Id: ForcedExpiratoryVolume1SecPostbronchodilator-mLChange
 Title: "Forced Expiratory Volume In 1 Second (FEV1) Post-bronchodilator mL Change"
-Description: "Forced expiratory volume in one second, mL change from pre-bronchodilator to post-bronchodilator"
+Description: """The volume (mL) change in forced expiratory volume in one second (FEV1) between a measurement performed pre-bronchodilator and a measurement performed post-bronchodilator.
+
+Forced expiratory volume in one second is the total volume of air, in liters, that can be forcibly exhaled in one second.
+
+This profile is for the difference in volume between two forced expiratory volume in one second measurements: one performed pre-bronchodilator, and the other performed post-bronchodilator. Measurements of forced expiratory volume (and spirometry tests in general) may be performed both before and after administering a bronchodilator to the patient, in order to study the bronchodilator's effectiveness for treating their respiratory conditions.
+"""
 * code
   * text = "FEV1 volume change"
 * value[x] only Quantity
@@ -141,7 +194,11 @@ Profile: ForcedExpiratoryVolume1SecPostbronchodilator_PercentChange
 Parent: Observation
 Id: ForcedExpiratoryVolume1SecPostbronchodilator-PercentChange
 Title: "Forced Expiratory Volume In 1 Second (FEV1) Post-bronchodilator Percent Change"
-Description: "Forced expiratory volume in one second, percent change from pre-bronchodilator to post-bronchodilator"
+Description: """The percent change in forced expiratory volume in one second (FEV1) between a measurement performed pre-bronchodilator and a measurement performed post-bronchodilator.
+
+Forced expiratory volume in one second is the total volume of air, in liters, that can be forcibly exhaled in one second.
+
+This profile is for the percent change between two forced expiratory volume in one secondmeasurements: one performed pre-bronchodilator, and the other performed post-bronchodilator. Measurements of forced expiratory volume (and spirometry tests in general) may be performed both before and after administering a bronchodilator to the patient, in order to study the bronchodilator's effectiveness for treating their respiratory conditions."""
 * code
   * text = "FEV1 percent change"
 * value[x] only Quantity

--- a/input/fsh/Profiles/spirometry/FEV1.fsh
+++ b/input/fsh/Profiles/spirometry/FEV1.fsh
@@ -198,7 +198,7 @@ Description: """The percent change in forced expiratory volume in one second (FE
 
 Forced expiratory volume in one second is the total volume of air, in liters, that can be forcibly exhaled in one second.
 
-This profile is for the percent change between two forced expiratory volume in one secondmeasurements: one performed pre-bronchodilator, and the other performed post-bronchodilator. Measurements of forced expiratory volume (and spirometry tests in general) may be performed both before and after administering a bronchodilator to the patient, in order to study the bronchodilator's effectiveness for treating their respiratory conditions."""
+This profile is for the percent change between two forced expiratory volume in one second measurements: one performed pre-bronchodilator, and the other performed post-bronchodilator. Measurements of forced expiratory volume (and spirometry tests in general) may be performed both before and after administering a bronchodilator to the patient, in order to study the bronchodilator's effectiveness for treating their respiratory conditions."""
 * code
   * text = "FEV1 percent change"
 * value[x] only Quantity

--- a/input/fsh/Profiles/spirometry/FEV1_over_FVC.fsh
+++ b/input/fsh/Profiles/spirometry/FEV1_over_FVC.fsh
@@ -8,7 +8,11 @@ Profile: FEV1_over_FVC
 Parent: Observation
 Id: FEV1-over-FVC
 Title: "FEV1/FVC"
-Description: "FEV1/FVC"
+Description: """The ratio of forced expiratory volume in one second to forced vital capacity (FEV1/FVC).
+
+The ratio of forced expiratory volume in one second to forced vital capacity is useful because different respiratory conditions affect each term in the ratio in different ways.
+
+This profile is for a FEV1/FVC observation which was not specified as performed pre or post-bronchodilator. Measurements of FEV1/FVC (and spirometry tests in general) may be performed both before and after administering a bronchodilator to the patient, in order to study the bronchodilator's effectiveness for treating their respiratory conditions."""
 * code = $LNC#19926-5 "FEV1/FVC"
 * value[x] only Quantity
 * valueQuantity
@@ -20,7 +24,13 @@ Profile: FEV1_over_FVC_Zscore
 Parent: Observation
 Id: FEV1-over-FVC-Zscore
 Title: "FEV1/FVC Zscore"
-Description: "FEV1/FVC (z-score)"
+Description: """The Zscore of the of forced expiratory volume in one second to forced vital capacity (FEV1/FVC).
+
+The ratio of forced expiratory volume in one second to forced vital capacity is useful because different respiratory conditions affect each term in the ratio in different ways.
+
+The Zscore of a measured value is determined by comparing the measured value to some reference distribution based on the patient's demographic information. The Zscore is useful as an indicator of how abnormal the measured value is.
+
+This profile is for the Zscore of a FEV1/FVC observation which was not specified as performed pre or post-bronchodilator. Measurements of FEV1/FVC (and spirometry tests in general) may be performed both before and after administering a bronchodilator to the patient, in order to study the bronchodilator's effectiveness for treating their respiratory conditions."""
 * code
   * text = "FEV1/FVC (z-score)"
 * value[x] only Quantity
@@ -37,7 +47,11 @@ Profile: FEV1_over_FVC_PreBronchodilator
 Parent: Observation
 Id: FEV1-over-FVC-PreBronchodilator
 Title: "FEV1/FVC Pre-bronchodilator"
-Description: "FEV1/FVC pre-bronchodilator"
+Description: """The ratio of forced expiratory volume in one second to forced vital capacity (FEV1/FVC) performed pre-bronchodilator.
+
+The ratio of forced expiratory volume in one second to forced vital capacity is useful because different respiratory conditions affect each term in the ratio in different ways.
+
+This profile is for a FEV1/FVC observation which was performed pre-bronchodilator. Measurements of FEV1/FVC (and spirometry tests in general) may be performed both before and after administering a bronchodilator to the patient, in order to study the bronchodilator's effectiveness for treating their respiratory conditions."""
 * code
   * coding = $LNC#19926-5 "FEV1/FVC"
   * text = "FEV1/FVC pre-bronchodilator"
@@ -51,7 +65,13 @@ Profile: FEV1_over_FVC_PreBronchodilator_Zscore
 Parent: Observation
 Id: FEV1-over-FVC-PreBronchodilator-Zscore
 Title: "FEV1/FVC Pre-bronchodilator Zscore"
-Description: "FEV1/FVC (z-score) pre-bronchodilator"
+Description: """The Zscore of the of forced expiratory volume in one second to forced vital capacity (FEV1/FVC) performed pre-bronchodilator.
+
+The ratio of forced expiratory volume in one second to forced vital capacity is useful because different respiratory conditions affect each term in the ratio in different ways.
+
+The Zscore of a measured value is determined by comparing the measured value to some reference distribution based on the patient's demographic information. The Zscore is useful as an indicator of how abnormal the measured value is.
+
+This profile is for the Zscore of a FEV1/FVC observation which was performed pre-bronchodilator. Measurements of FEV1/FVC (and spirometry tests in general) may be performed both before and after administering a bronchodilator to the patient, in order to study the bronchodilator's effectiveness for treating their respiratory conditions."""
 * code
   * text = "FEV1/FVC (z-score) pre-bronchodilator"
 * value[x] only Quantity
@@ -68,7 +88,11 @@ Profile: FEV1_over_FVC_PostBronchodilator
 Parent: Observation
 Id: FEV1-over-FVC-PostBronchodilator
 Title: "FEV1/FVC Post-bronchodilator"
-Description: "FEV1/FVC post-bronchodilator"
+Description: """The ratio of forced expiratory volume in one second to forced vital capacity (FEV1/FVC) performed post-bronchodilator.
+
+The ratio of forced expiratory volume in one second to forced vital capacity is useful because different respiratory conditions affect each term in the ratio in different ways.
+
+This profile is for a FEV1/FVC observation which was performed post-bronchodilator. Measurements of FEV1/FVC (and spirometry tests in general) may be performed both before and after administering a bronchodilator to the patient, in order to study the bronchodilator's effectiveness for treating their respiratory conditions."""
 * code
   * coding = $LNC#19926-5 "FEV1/FVC"
   * text = "FEV1/FVC post-bronchodilator"
@@ -82,7 +106,13 @@ Profile: FEV1_over_FVC_PostBronchodilator_Zscore
 Parent: Observation
 Id: FEV1-over-FVC-PostBronchodilator-Zscore
 Title: "FEV1/FVC Post-bronchodilator Zscore"
-Description: "FEV1/FVC (z-score) post-bronchodilator"
+Description: """The Zscore of the of forced expiratory volume in one second to forced vital capacity (FEV1/FVC) performed post-bronchodilator.
+
+The ratio of forced expiratory volume in one second to forced vital capacity is useful because different respiratory conditions affect each term in the ratio in different ways.
+
+The Zscore of a measured value is determined by comparing the measured value to some reference distribution based on the patient's demographic information. The Zscore is useful as an indicator of how abnormal the measured value is.
+
+This profile is for the Zscore of a FEV1/FVC observation which was performed post-bronchodilator. Measurements of FEV1/FVC (and spirometry tests in general) may be performed both before and after administering a bronchodilator to the patient, in order to study the bronchodilator's effectiveness for treating their respiratory conditions."""
 * code
   * text = "FEV1/FVC (z-score) post-bronchodilator"
 * value[x] only Quantity

--- a/input/fsh/Profiles/spirometry/FEV1_over_FVC.fsh
+++ b/input/fsh/Profiles/spirometry/FEV1_over_FVC.fsh
@@ -24,7 +24,7 @@ Profile: FEV1_over_FVC_Zscore
 Parent: Observation
 Id: FEV1-over-FVC-Zscore
 Title: "FEV1/FVC Zscore"
-Description: """The Zscore of the of forced expiratory volume in one second to forced vital capacity (FEV1/FVC).
+Description: """The Zscore of the ratio of forced expiratory volume in one second to forced vital capacity (FEV1/FVC).
 
 The ratio of forced expiratory volume in one second to forced vital capacity is useful because different respiratory conditions affect each term in the ratio in different ways.
 
@@ -65,7 +65,7 @@ Profile: FEV1_over_FVC_PreBronchodilator_Zscore
 Parent: Observation
 Id: FEV1-over-FVC-PreBronchodilator-Zscore
 Title: "FEV1/FVC Pre-bronchodilator Zscore"
-Description: """The Zscore of the of forced expiratory volume in one second to forced vital capacity (FEV1/FVC) performed pre-bronchodilator.
+Description: """The Zscore of the ratio of forced expiratory volume in one second to forced vital capacity (FEV1/FVC) performed pre-bronchodilator.
 
 The ratio of forced expiratory volume in one second to forced vital capacity is useful because different respiratory conditions affect each term in the ratio in different ways.
 
@@ -106,7 +106,7 @@ Profile: FEV1_over_FVC_PostBronchodilator_Zscore
 Parent: Observation
 Id: FEV1-over-FVC-PostBronchodilator-Zscore
 Title: "FEV1/FVC Post-bronchodilator Zscore"
-Description: """The Zscore of the of forced expiratory volume in one second to forced vital capacity (FEV1/FVC) performed post-bronchodilator.
+Description: """The Zscore of the ratio of forced expiratory volume in one second to forced vital capacity (FEV1/FVC) performed post-bronchodilator.
 
 The ratio of forced expiratory volume in one second to forced vital capacity is useful because different respiratory conditions affect each term in the ratio in different ways.
 

--- a/input/fsh/Profiles/spirometry/FVC.fsh
+++ b/input/fsh/Profiles/spirometry/FVC.fsh
@@ -10,7 +10,7 @@ Id: ForcedVitalCapacity
 Title: "Forced Vital Capacity (FVC)"
 Description: """A measurement of forced vital capacity (FVC).
 
-Forced vital capacity is the total volume of air (in liters) that can be forcibly exhaled after taking as deep a breath as possible.
+Forced vital capacity is the total volume of air, in liters, that can be forcibly exhaled after taking as deep a breath as possible.
 
 This profile is for a forced vital capacity observation which was not specified as performed pre or post-bronchodilator. Measurements of forced vital capacity (and spirometry tests in general) may be performed both before and after administering a bronchodilator to the patient, in order to study the bronchodilator's effectiveness for treating their respiratory conditions."""
 * code = $LNC#19870-5 "Forced vital capacity [Volume] Respiratory system"
@@ -26,7 +26,7 @@ Id: ForcedVitalCapacity-Zscore
 Title: "Forced Vital Capacity (FVC) Zscore"
 Description: """The Zscore of a forced vital capacity (FVC) measurement.
 
-Forced vital capacity is the total volume of air (in liters) that can be forcibly exhaled after taking as deep a breath as possible.
+Forced vital capacity is the total volume of air, in liters, that can be forcibly exhaled after taking as deep a breath as possible.
 
 The Zscore of a measured value is determined by comparing the measured value to some reference distribution based on the patient's demographic information. The Zscore is useful as an indicator of how abnormal the measured value is.
 
@@ -45,7 +45,7 @@ Id: ForcedVitalCapacity-PercentOfPredicted
 Title: "Forced Vital Capacity (FVC) Percent Of Predicted"
 Description: """The ratio of a forced vital capacity (FVC) measurement to some predicted value, expressed as the percentage `measured/predicted`. This is also referred to as \"% predicted\" or \"% pred\".
 
-Forced vital capacity is the total volume of air (in liters) that can be forcibly exhaled after taking as deep a breath as possible.
+Forced vital capacity is the total volume of air, in liters, that can be forcibly exhaled after taking as deep a breath as possible.
 
 The predicted value (also referred to as the \"reference value\") is determined by the patient's demographic information. The ratio of the measured value to the predicted value is useful as an indicator of how abnormal the measured value is.
 
@@ -66,7 +66,7 @@ Id: ForcedVitalCapacityPreBronchodilator
 Title: "Forced Vital Capacity (FVC) Pre-bronchodilator"
 Description: """A measurement of forced vital capacity (FVC) performed pre-bronchodilator.
 
-Forced vital capacity is the total volume of air (in liters) that can be forcibly exhaled after taking as deep a breath as possible.
+Forced vital capacity is the total volume of air, in liters, that can be forcibly exhaled after taking as deep a breath as possible.
 
 This profile is for a forced vital capacity observation which was performed pre-bronchodilator. Measurements of forced vital capacity (and spirometry tests in general) may be performed both before and after administering a bronchodilator to the patient, in order to study the bronchodilator's effectiveness for treating their respiratory conditions."""
 * code = $LNC#19876-2 "Forced vital capacity [Volume] Respiratory system by Spirometry --pre bronchodilation"
@@ -82,7 +82,7 @@ Id: ForcedVitalCapacityPreBronchodilator-Zscore
 Title: "Forced Vital Capacity (FVC) Pre-bronchodilator Zscore"
 Description: """The Zscore of a forced vital capacity (FVC) measurement performed pre-bronchodilator.
 
-Forced vital capacity is the total volume of air (in liters) that can be forcibly exhaled after taking as deep a breath as possible.
+Forced vital capacity is the total volume of air, in liters, that can be forcibly exhaled after taking as deep a breath as possible.
 
 The Zscore of a measured value is determined by comparing the measured value to some reference distribution based on the patient's demographic information. The Zscore is useful as an indicator of how abnormal the measured value is.
 
@@ -101,7 +101,7 @@ Id: ForcedVitalCapacityPreBronchodilator-PercentOfPredicted
 Title: "Forced Vital Capacity (FVC) Pre-bronchodilator Percent Of Predicted"
 Description: """The ratio of a forced vital capacity (FVC) measurement performed pre-bronchodilator to some predicted value, expressed as the percentage `measured/predicted`. This is also referred to as \"% predicted\" or \"% pred\".
 
-Forced vital capacity is the total volume of air (in liters) that can be forcibly exhaled after taking as deep a breath as possible.
+Forced vital capacity is the total volume of air, in liters, that can be forcibly exhaled after taking as deep a breath as possible.
 
 The predicted value (also referred to as the \"reference value\") is determined by the patient's demographic information. The ratio of the measured value to the predicted value is useful as an indicator of how abnormal the measured value is.
 
@@ -122,7 +122,7 @@ Id: ForcedVitalCapacityPostBronchodilator
 Title: "Forced Vital Capacity (FVC) Post-bronchodilator"
 Description: """A measurement of forced vital capacity (FVC) performed post-bronchodilator.
 
-Forced vital capacity is the total volume of air (in liters) that can be forcibly exhaled after taking as deep a breath as possible.
+Forced vital capacity is the total volume of air, in liters, that can be forcibly exhaled after taking as deep a breath as possible.
 
 This profile is for a forced vital capacity observation which was performed post-bronchodilator. Measurements of forced vital capacity (and spirometry tests in general) may be performed both before and after administering a bronchodilator to the patient, in order to study the bronchodilator's effectiveness for treating their respiratory conditions."""
 * code =  $LNC#19874-7 "Forced vital capacity [Volume] Respiratory system by Spirometry --post bronchodilation"
@@ -138,7 +138,7 @@ Id: ForcedVitalCapacityPostBronchodilator-Zscore
 Title: "Forced Vital Capacity (FVC) Post-bronchodilator Zscore"
 Description: """The Zscore of a forced vital capacity (FVC) measurement performed post-bronchodilator.
 
-Forced vital capacity is the total volume of air (in liters) that can be forcibly exhaled after taking as deep a breath as possible.
+Forced vital capacity is the total volume of air, in liters, that can be forcibly exhaled after taking as deep a breath as possible.
 
 The Zscore of a measured value is determined by comparing the measured value to some reference distribution based on the patient's demographic information. The Zscore is useful as an indicator of how abnormal the measured value is.
 
@@ -157,7 +157,7 @@ Id: ForcedVitalCapacityPostBronchodilator-PercentOfPredicted
 Title: "Forced Vital Capacity (FVC) Post-bronchodilator Percent Of Predicted"
 Description: """The ratio of a forced vital capacity (FVC) measurement performed post-bronchodilator to some predicted value, expressed as the percentage `measured/predicted`. This is also referred to as \"% predicted\" or \"% pred\".
 
-Forced vital capacity is the total volume of air (in liters) that can be forcibly exhaled after taking as deep a breath as possible.
+Forced vital capacity is the total volume of air, in liters, that can be forcibly exhaled after taking as deep a breath as possible.
 
 The predicted value (also referred to as the \"reference value\") is determined by the patient's demographic information. The ratio of the measured value to the predicted value is useful as an indicator of how abnormal the measured value is.
 
@@ -175,7 +175,7 @@ Id: ForcedVitalCapacityPostBronchodilator-mLChange
 Title: "Forced Vital Capacity (FVC) Post-bronchodilator mL Change"
 Description: """The volume (mL) change in forced vital capacity (FVC) between a measurement performed pre-bronchodilator and a measurement performed post-bronchodilator.
 
-Forced vital capacity is the total volume of air (in liters) that can be forcibly exhaled after taking as deep a breath as possible.
+Forced vital capacity is the total volume of air, in liters, that can be forcibly exhaled after taking as deep a breath as possible.
 
 This profile is for the difference in volume between two forced vital capacity measurements: one performed pre-bronchodilator, and the other performed post-bronchodilator. Measurements of forced vital capacity (and spirometry tests in general) may be performed both before and after administering a bronchodilator to the patient, in order to study the bronchodilator's effectiveness for treating their respiratory conditions."""
 * code
@@ -192,7 +192,7 @@ Id: ForcedVitalCapacityPostBronchodilator-PercentChange
 Title: "Forced Vital Capacity (FVC) Post-bronchodilator Percent Change"
 Description: """The percent change in forced vital capacity (FVC) between a measurement performed pre-bronchodilator and a measurement performed post-bronchodilator.
 
-Forced vital capacity is the total volume of air (in liters) that can be forcibly exhaled after taking as deep a breath as possible.
+Forced vital capacity is the total volume of air, in liters, that can be forcibly exhaled after taking as deep a breath as possible.
 
 This profile is for the percent change between two forced vital capacity measurements: one performed pre-bronchodilator, and the other performed post-bronchodilator. Measurements of forced vital capacity (and spirometry tests in general) may be performed both before and after administering a bronchodilator to the patient, in order to study the bronchodilator's effectiveness for treating their respiratory conditions."""
 * code = $LNC#69982-7 "FVC percent change Respiratory system"

--- a/input/fsh/Profiles/spirometry/FVC.fsh
+++ b/input/fsh/Profiles/spirometry/FVC.fsh
@@ -12,8 +12,7 @@ Description: """A measurement of forced vital capacity (FVC).
 
 Forced vital capacity is the total volume of air (in liters) that can be forcibly exhaled after taking as deep a breath as possible.
 
-This profile is for a forced vital capacity observation which was not specified as performed pre or post-bronchodilator. Measurements of forced vital capacity (and spirometry tests in general) may be performed both before and after administering a bronchodilator to the patient, in order to study the bronchodilator's effectiveness for treating their respiratory conditions.
-"""
+This profile is for a forced vital capacity observation which was not specified as performed pre or post-bronchodilator. Measurements of forced vital capacity (and spirometry tests in general) may be performed both before and after administering a bronchodilator to the patient, in order to study the bronchodilator's effectiveness for treating their respiratory conditions."""
 * code = $LNC#19870-5 "Forced vital capacity [Volume] Respiratory system"
 * value[x] only Quantity
 * valueQuantity
@@ -31,8 +30,7 @@ Forced vital capacity is the total volume of air (in liters) that can be forcibl
 
 The Zscore of a measured value is determined by comparing the measured value to some reference distribution based on the patient's demographic information. The Zscore is useful as an indicator of how abnormal the measured value is.
 
-This profile is for the Zscore of a forced vital capacity observation which was not specified as performed pre or post-bronchodilator. Measurements of forced vital capacity (and spirometry tests in general) may be performed both before and after administering a bronchodilator to the patient, in order to study the bronchodilator's effectiveness for treating their respiratory conditions.
-"""
+This profile is for the Zscore of a forced vital capacity observation which was not specified as performed pre or post-bronchodilator. Measurements of forced vital capacity (and spirometry tests in general) may be performed both before and after administering a bronchodilator to the patient, in order to study the bronchodilator's effectiveness for treating their respiratory conditions."""
 * code
   * text = "Forced vital capacity (z-score)"
 * value[x] only Quantity
@@ -51,8 +49,7 @@ Forced vital capacity is the total volume of air (in liters) that can be forcibl
 
 The predicted value (also referred to as the \"reference value\") is determined by the patient's demographic information. The ratio of the measured value to the predicted value is useful as an indicator of how abnormal the measured value is.
 
-This profile is for the measured/predicted ratio of a forced vital capacity observation which was not specified as performed pre or post-bronchodilator. Measurements of forced vital capacity (and spirometry tests in general) may be performed both before and after administering a bronchodilator to the patient, in order to study the bronchodilator's effectiveness for treating their respiratory conditions.
-"""
+This profile is for the measured/predicted ratio of a forced vital capacity observation which was not specified as performed pre or post-bronchodilator. Measurements of forced vital capacity (and spirometry tests in general) may be performed both before and after administering a bronchodilator to the patient, in order to study the bronchodilator's effectiveness for treating their respiratory conditions."""
 * code = $LNC#19872-1 "FVC measured/predicted"
 * value[x] only Quantity
   * unit = "%"
@@ -71,8 +68,7 @@ Description: """A measurement of forced vital capacity (FVC) performed pre-bronc
 
 Forced vital capacity is the total volume of air (in liters) that can be forcibly exhaled after taking as deep a breath as possible.
 
-This profile is for a forced vital capacity observation which was performed pre-bronchodilator. Measurements of forced vital capacity (and spirometry tests in general) may be performed both before and after administering a bronchodilator to the patient, in order to study the bronchodilator's effectiveness for treating their respiratory conditions.
-"""
+This profile is for a forced vital capacity observation which was performed pre-bronchodilator. Measurements of forced vital capacity (and spirometry tests in general) may be performed both before and after administering a bronchodilator to the patient, in order to study the bronchodilator's effectiveness for treating their respiratory conditions."""
 * code = $LNC#19876-2 "Forced vital capacity [Volume] Respiratory system by Spirometry --pre bronchodilation"
 * value[x] only Quantity
 * valueQuantity
@@ -90,8 +86,7 @@ Forced vital capacity is the total volume of air (in liters) that can be forcibl
 
 The Zscore of a measured value is determined by comparing the measured value to some reference distribution based on the patient's demographic information. The Zscore is useful as an indicator of how abnormal the measured value is.
 
-This profile is for the Zscore of a forced vital capacity observation which was performed pre-bronchodilator. Measurements of forced vital capacity (and spirometry tests in general) may be performed both before and after administering a bronchodilator to the patient, in order to study the bronchodilator's effectiveness for treating their respiratory conditions.
-"""
+This profile is for the Zscore of a forced vital capacity observation which was performed pre-bronchodilator. Measurements of forced vital capacity (and spirometry tests in general) may be performed both before and after administering a bronchodilator to the patient, in order to study the bronchodilator's effectiveness for treating their respiratory conditions."""
 * code
   * text = "Forced vital capacity (z-score) pre-bronchodilator"
 * value[x] only Quantity
@@ -110,8 +105,7 @@ Forced vital capacity is the total volume of air (in liters) that can be forcibl
 
 The predicted value (also referred to as the \"reference value\") is determined by the patient's demographic information. The ratio of the measured value to the predicted value is useful as an indicator of how abnormal the measured value is.
 
-This profile is for the measured/predicted ratio of a forced vital capacity observation which was performed pre-bronchodilator. Measurements of forced vital capacity (and spirometry tests in general) may be performed both before and after administering a bronchodilator to the patient, in order to study the bronchodilator's effectiveness for treating their respiratory conditions.
-"""
+This profile is for the measured/predicted ratio of a forced vital capacity observation which was performed pre-bronchodilator. Measurements of forced vital capacity (and spirometry tests in general) may be performed both before and after administering a bronchodilator to the patient, in order to study the bronchodilator's effectiveness for treating their respiratory conditions."""
 * code = $LNC#19871-3 "FVC pre bronchodilation measured/predicted"
 * value[x] only Quantity
   * unit = "%"
@@ -130,8 +124,7 @@ Description: """A measurement of forced vital capacity (FVC) performed post-bron
 
 Forced vital capacity is the total volume of air (in liters) that can be forcibly exhaled after taking as deep a breath as possible.
 
-This profile is for a forced vital capacity observation which was performed post-bronchodilator. Measurements of forced vital capacity (and spirometry tests in general) may be performed both before and after administering a bronchodilator to the patient, in order to study the bronchodilator's effectiveness for treating their respiratory conditions.
-"""
+This profile is for a forced vital capacity observation which was performed post-bronchodilator. Measurements of forced vital capacity (and spirometry tests in general) may be performed both before and after administering a bronchodilator to the patient, in order to study the bronchodilator's effectiveness for treating their respiratory conditions."""
 * code =  $LNC#19874-7 "Forced vital capacity [Volume] Respiratory system by Spirometry --post bronchodilation"
 * value[x] only Quantity
 * valueQuantity
@@ -149,8 +142,7 @@ Forced vital capacity is the total volume of air (in liters) that can be forcibl
 
 The Zscore of a measured value is determined by comparing the measured value to some reference distribution based on the patient's demographic information. The Zscore is useful as an indicator of how abnormal the measured value is.
 
-This profile is for the Zscore of a forced vital capacity observation which was performed post-bronchodilator. Measurements of forced vital capacity (and spirometry tests in general) may be performed both before and after administering a bronchodilator to the patient, in order to study the bronchodilator's effectiveness for treating their respiratory conditions.
-"""
+This profile is for the Zscore of a forced vital capacity observation which was performed post-bronchodilator. Measurements of forced vital capacity (and spirometry tests in general) may be performed both before and after administering a bronchodilator to the patient, in order to study the bronchodilator's effectiveness for treating their respiratory conditions."""
 * code
   * text = "Forced vital capacity (z-score) post-bronchodilator"
 * value[x] only Quantity
@@ -169,8 +161,7 @@ Forced vital capacity is the total volume of air (in liters) that can be forcibl
 
 The predicted value (also referred to as the \"reference value\") is determined by the patient's demographic information. The ratio of the measured value to the predicted value is useful as an indicator of how abnormal the measured value is.
 
-This profile is for the measured/predicted ratio of a forced vital capacity observation which was performed post-bronchodilator. Measurements of forced vital capacity (and spirometry tests in general) may be performed both before and after administering a bronchodilator to the patient, in order to study the bronchodilator's effectiveness for treating their respiratory conditions.
-"""
+This profile is for the measured/predicted ratio of a forced vital capacity observation which was performed post-bronchodilator. Measurements of forced vital capacity (and spirometry tests in general) may be performed both before and after administering a bronchodilator to the patient, in order to study the bronchodilator's effectiveness for treating their respiratory conditions."""
 * code = $LNC#19873-9 "FVC post bronchodilation measured/predicted"
 * value[x] only Quantity
 * valueQuantity
@@ -186,8 +177,7 @@ Description: """The volume (mL) change in forced vital capacity (FVC) between a 
 
 Forced vital capacity is the total volume of air (in liters) that can be forcibly exhaled after taking as deep a breath as possible.
 
-This profile is for the difference in volume between two forced vital capacity measurements: one performed pre-bronchodilator, and the other performed post-bronchodilator. Measurements of forced vital capacity (and spirometry tests in general) may be performed both before and after administering a bronchodilator to the patient, in order to study the bronchodilator's effectiveness for treating their respiratory conditions.
-"""
+This profile is for the difference in volume between two forced vital capacity measurements: one performed pre-bronchodilator, and the other performed post-bronchodilator. Measurements of forced vital capacity (and spirometry tests in general) may be performed both before and after administering a bronchodilator to the patient, in order to study the bronchodilator's effectiveness for treating their respiratory conditions."""
 * code
   * text = "Forced vital capacity, post-bronchodilator change from pre-bronchodilator (mL)"
 * value[x] only Quantity
@@ -204,8 +194,7 @@ Description: """The percent change in forced vital capacity (FVC) between a meas
 
 Forced vital capacity is the total volume of air (in liters) that can be forcibly exhaled after taking as deep a breath as possible.
 
-This profile is for the percent change between two forced vital capacity measurements: one performed pre-bronchodilator, and the other performed post-bronchodilator. Measurements of forced vital capacity (and spirometry tests in general) may be performed both before and after administering a bronchodilator to the patient, in order to study the bronchodilator's effectiveness for treating their respiratory conditions.
-"""
+This profile is for the percent change between two forced vital capacity measurements: one performed pre-bronchodilator, and the other performed post-bronchodilator. Measurements of forced vital capacity (and spirometry tests in general) may be performed both before and after administering a bronchodilator to the patient, in order to study the bronchodilator's effectiveness for treating their respiratory conditions."""
 * code = $LNC#69982-7 "FVC percent change Respiratory system"
 * value[x] only Quantity
 * valueQuantity


### PR DESCRIPTION
Added descriptions for the rest of the spirometry profiles, and partially for diffusing capacity profiles. 

Notes/TODOs:
- FEV1/FVC
  - Descriptions should mention that pre/post corresponds to when the FEV1 and FVC measurements were taken. Since FEV/FVC is derived from those, rather than measured directly.
  - In fact, maybe we slice `derivedFrom` in those to say it can have `0..1` FEV1 or FVC Observations (likewise for other Profiles which are always derived from other Observations, like VI/VC).
- VI/VC
  - Expand description to explain what VI and VC are, and how they are measured or calculated.
- TLC_sb
  - Expand description to explain how this is measured or calculated.
- VA
  - Expand description to explain how this is measured or calculated.
- DLCO
  - Expand description to explain why carbon monoxide is used, why the unit is mL/min/mmHg, etc
  - TODO: Add descriptions to every other DLCO Profile after `DLCO`.
- KCO
  - TODO: Add descriptions.
- PulmonaryFunctionTestDiagnosticReport
  - Expand description to explain usage, what it does, what it means.