### PR TITLE
fix 'Contents' links and update with new sections

### DIFF
--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -1,12 +1,15 @@
 <span class="label label-danger">NOTE</span> This implementation guide is under **active development** on [GitHub](https://github.com/automate-medical/pft-ig/issues), and **may change without notice**. Please comment on or [create](https://github.com/automate-medical/pft-ig/issues/new) an issue on GitHub if you have questions, comments, or suggestions. Contributions are welcome! Development has been sponsored by [Automate Medical](https://www.automatemedical.com/).
 
 ### Contents
-1. [Introduction](#introduction)
+1. [Scope](#scope)
 2. [Background](#background)
 3. [Usage](#usage)
 4. [Limitations](#limitations)
-  1. [Gaps in coding](#gaps-in-observation-coding)
-5. [Authors](#authors)
+    1. [Gaps in coding](#gaps-in-coding)
+    2. [Non-exhaustive](#non-exhaustive)
+    3. [Review status](#review-status)
+6. [Contact](#contact)
+7. [Authors](#authors)
 
 ### Scope
 


### PR DESCRIPTION
IG build raised two errors for markdown links not being resolved:
- '#introduction'
- '#gaps-in-observation-coding'

I renamed 'Introduction' to 'Scope' and corrected 'Gaps in Coding'.
I also fixed the subsection indentation for 'Gaps in Coding' and
added links for missing sections.